### PR TITLE
Add guards against multiple initialization of spawn context

### DIFF
--- a/python/mneme/cli.py
+++ b/python/mneme/cli.py
@@ -5,7 +5,11 @@ import json
 import math
 import multiprocessing
 
-multiprocessing.set_start_method("spawn")
+try:
+    multiprocessing.set_start_method("spawn")
+except RuntimeError:
+    pass
+
 import os
 import sys
 import time

--- a/setup.py
+++ b/setup.py
@@ -232,5 +232,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["optuna>=4.4"],
+    install_requires=["optuna>=4.4", "scipy"],
 )


### PR DESCRIPTION
Fixes issue #28
- Add a try catch to protect against multiple initialization of spawn contexts
- Add `scipy` to as it is needed by Optuna when using `QMCSampler`. Note that: I could have added `optuna[optional]` but it installs a lot of extra packages (PyTorch, CUDNN etc)