### PR TITLE
WIP: Fix ordering of prune, link and internalize in replay

### DIFF
--- a/python/mneme/proteus/jit.py
+++ b/python/mneme/proteus/jit.py
@@ -93,12 +93,12 @@ def codegen_object(
     return result
 
 
-def link_llvm_modules(modules: List[str], kernel_name: str):
+def link_llvm_modules(modules: List[str], kernel_name: str, prune: bool , internalize: bool):
     c_strings = [c_char_p(s.encode("utf-8")) for s in modules]
     ArrayType = c_char_p * len(c_strings)
     c_array = ArrayType(*c_strings)
     Mod = ModuleRef(
-        ffi.lib.ProteusPY_linkModules(c_array, len(modules), get_global_context(), kernel_name.encode('utf-8'), True, True), 
+        ffi.lib.ProteusPY_linkModules(c_array, len(modules), get_global_context(), kernel_name.encode('utf-8'), prune, internalize), 
         get_global_context(),
     )
     return Mod

--- a/python/mneme/proteus/jit.py
+++ b/python/mneme/proteus/jit.py
@@ -13,7 +13,7 @@ ffi.lib.ProteusPY_optimize.argtypes = [ffi.LLVMModuleRef, c_char_p, c_char_p, c_
 ffi.lib.ProteusPY_internalize.argtypes = [ffi.LLVMModuleRef, c_char_p]
 ffi.lib.ProteusPY_codeGenObject.argtypes = [ffi.LLVMModuleRef, c_char_p, c_bool, c_uint]
 ffi.lib.ProteusPY_codeGenObject.restype = ffi.LLVMMemBufferRef
-ffi.lib.ProteusPY_linkModules.argtypes = [POINTER(c_char_p), c_int, ffi.LLVMContextRef]
+ffi.lib.ProteusPY_linkModules.argtypes = [POINTER(c_char_p), c_int, ffi.LLVMContextRef, c_bool, c_bool]
 ffi.lib.ProteusPY_linkModules.restype = ffi.LLVMModuleRef
 ffi.lib.ProteusPY_specializeArguments.argtypes = [
     ffi.LLVMModuleRef,  # Module
@@ -98,7 +98,7 @@ def link_llvm_modules(modules: List[str]):
     ArrayType = c_char_p * len(c_strings)
     c_array = ArrayType(*c_strings)
     Mod = ModuleRef(
-        ffi.lib.ProteusPY_linkModules(c_array, len(modules), get_global_context()),
+        ffi.lib.ProteusPY_linkModules(c_array, len(modules), get_global_context(), True, True), 
         get_global_context(),
     )
     return Mod

--- a/python/mneme/proteus/jit.py
+++ b/python/mneme/proteus/jit.py
@@ -13,7 +13,7 @@ ffi.lib.ProteusPY_optimize.argtypes = [ffi.LLVMModuleRef, c_char_p, c_char_p, c_
 ffi.lib.ProteusPY_internalize.argtypes = [ffi.LLVMModuleRef, c_char_p]
 ffi.lib.ProteusPY_codeGenObject.argtypes = [ffi.LLVMModuleRef, c_char_p, c_bool, c_uint]
 ffi.lib.ProteusPY_codeGenObject.restype = ffi.LLVMMemBufferRef
-ffi.lib.ProteusPY_linkModules.argtypes = [POINTER(c_char_p), c_int, ffi.LLVMContextRef, c_bool, c_bool]
+ffi.lib.ProteusPY_linkModules.argtypes = [POINTER(c_char_p), c_int, ffi.LLVMContextRef, c_char_p, c_bool, c_bool]
 ffi.lib.ProteusPY_linkModules.restype = ffi.LLVMModuleRef
 ffi.lib.ProteusPY_specializeArguments.argtypes = [
     ffi.LLVMModuleRef,  # Module

--- a/python/mneme/proteus/jit.py
+++ b/python/mneme/proteus/jit.py
@@ -93,12 +93,12 @@ def codegen_object(
     return result
 
 
-def link_llvm_modules(modules: List[str]):
+def link_llvm_modules(modules: List[str], kernel_name: str):
     c_strings = [c_char_p(s.encode("utf-8")) for s in modules]
     ArrayType = c_char_p * len(c_strings)
     c_array = ArrayType(*c_strings)
     Mod = ModuleRef(
-        ffi.lib.ProteusPY_linkModules(c_array, len(modules), get_global_context(), True, True), 
+        ffi.lib.ProteusPY_linkModules(c_array, len(modules), get_global_context(), kernel_name.encode('utf-8'), True, True), 
         get_global_context(),
     )
     return Mod

--- a/python/mneme/recorded_execution.py
+++ b/python/mneme/recorded_execution.py
@@ -202,14 +202,7 @@ class RecordedExecution:
         if self._link_mod is not None:
             return self._link_mod
 
-        self._link_mod = jit.link_llvm_modules(self.llvm_files, self.kernel_name)
-
-        # Comment these, we will call this in the jit.cpp link
-        # if internalize:
-        #     jit.internalize(self._link_mod, self.kernel_name)
-
-        #  if prune:
-        #      jit.pruneIR(self._link_mod)
+        self._link_mod = jit.link_llvm_modules(self.llvm_files, self.kernel_name, prune, internalize)
 
         return self._link_mod
 

--- a/python/mneme/recorded_execution.py
+++ b/python/mneme/recorded_execution.py
@@ -204,11 +204,12 @@ class RecordedExecution:
 
         self._link_mod = jit.link_llvm_modules(self.llvm_files)
 
-        if internalize:
-            jit.internalize(self._link_mod, self.kernel_name)
+        # Comment these, we will call this in the jit.cpp link
+        # if internalize:
+        #     jit.internalize(self._link_mod, self.kernel_name)
 
-        if prune:
-            jit.pruneIR(self._link_mod)
+        #  if prune:
+        #      jit.pruneIR(self._link_mod)
 
         return self._link_mod
 

--- a/python/mneme/recorded_execution.py
+++ b/python/mneme/recorded_execution.py
@@ -202,7 +202,7 @@ class RecordedExecution:
         if self._link_mod is not None:
             return self._link_mod
 
-        self._link_mod = jit.link_llvm_modules(self.llvm_files)
+        self._link_mod = jit.link_llvm_modules(self.llvm_files, self.kernel_name)
 
         # Comment these, we will call this in the jit.cpp link
         # if internalize:

--- a/src/python/proteus/jit.cpp
+++ b/src/python/proteus/jit.cpp
@@ -62,7 +62,8 @@ ProteusPY_codeGenObject(LLVMModuleRef Mod, const char *DeviceArch, bool use_rtc,
 
 API_EXPORT(LLVMModuleRef)
 ProteusPY_linkModules(const char **LLVMIRFiles, int size,
-                      LLVMContextRef context, bool prune_flag=true, bool internalize_flag=true) {
+                      LLVMContextRef context, const char *KernelSym, 
+                      bool prune_flag=true, bool internalize_flag=true) {
   auto Ctx = unwrap(context);
   llvm::SmallVector<std::unique_ptr<llvm::Module>> RecordedModules;
   for (int i = 0; i < size; i++) {
@@ -80,18 +81,21 @@ ProteusPY_linkModules(const char **LLVMIRFiles, int size,
       LOG_FATAL("Error parsing bitcode: {}",
                 llvm::toString(ModuleOrErr.takeError()));
 
+    if(prune_flag) {
+      // Call prune here
+      // loop through recorded modules here?
+      pruneIR(ModuleOrErr, true);
+    }
+
     RecordedModules.emplace_back(std::move(ModuleOrErr.get()));
   }
   
-  if(prune_flag) {
-    // Call prune here
-    // loop through recorded modules here?
-  }
   auto Mod = proteus::linkModules(*unwrap(context), RecordedModules);
 
   if(internalize_flag) {
     // Call internalize here
     // loop through recorded modules here? what's the kernelsym arg?
+    internalize(Mod, KernelSym);
   }
 
   return wrap(Mod.release());

--- a/src/python/proteus/jit.cpp
+++ b/src/python/proteus/jit.cpp
@@ -82,9 +82,7 @@ ProteusPY_linkModules(const char **LLVMIRFiles, int size,
                 llvm::toString(ModuleOrErr.takeError()));
 
     if(prune_flag) {
-      // Call prune here
-      // loop through recorded modules here?
-      ProteusPY_pruneIR(wrap(ModuleOrErr->get()));
+      pruneIR(*ModuleOrErr->get());
     }
 
     RecordedModules.emplace_back(std::move(ModuleOrErr.get()));
@@ -93,9 +91,7 @@ ProteusPY_linkModules(const char **LLVMIRFiles, int size,
   auto Mod = proteus::linkModules(*unwrap(context), RecordedModules);
 
   if(internalize_flag) {
-    // Call internalize here
-    // loop through recorded modules here? what's the kernelsym arg?
-    ProteusPY_internalize(wrap(Mod.get()), KernelSym);
+    internalize(*Mod.get(), KernelSym);
   }
 
   return wrap(Mod.release());

--- a/src/python/proteus/jit.cpp
+++ b/src/python/proteus/jit.cpp
@@ -62,7 +62,7 @@ ProteusPY_codeGenObject(LLVMModuleRef Mod, const char *DeviceArch, bool use_rtc,
 
 API_EXPORT(LLVMModuleRef)
 ProteusPY_linkModules(const char **LLVMIRFiles, int size,
-                      LLVMContextRef context) {
+                      LLVMContextRef context, bool prune_flag=true, bool internalize_flag=true) {
   auto Ctx = unwrap(context);
   llvm::SmallVector<std::unique_ptr<llvm::Module>> RecordedModules;
   for (int i = 0; i < size; i++) {
@@ -82,8 +82,18 @@ ProteusPY_linkModules(const char **LLVMIRFiles, int size,
 
     RecordedModules.emplace_back(std::move(ModuleOrErr.get()));
   }
-
+  
+  if(prune_flag) {
+    // Call prune here
+    // loop through recorded modules here?
+  }
   auto Mod = proteus::linkModules(*unwrap(context), RecordedModules);
+
+  if(internalize_flag) {
+    // Call internalize here
+    // loop through recorded modules here? what's the kernelsym arg?
+  }
+
   return wrap(Mod.release());
 }
 

--- a/src/python/proteus/jit.cpp
+++ b/src/python/proteus/jit.cpp
@@ -84,7 +84,7 @@ ProteusPY_linkModules(const char **LLVMIRFiles, int size,
     if(prune_flag) {
       // Call prune here
       // loop through recorded modules here?
-      pruneIR(ModuleOrErr, true);
+      ProteusPY_pruneIR(wrap(ModuleOrErr->get()));
     }
 
     RecordedModules.emplace_back(std::move(ModuleOrErr.get()));
@@ -95,7 +95,7 @@ ProteusPY_linkModules(const char **LLVMIRFiles, int size,
   if(internalize_flag) {
     // Call internalize here
     // loop through recorded modules here? what's the kernelsym arg?
-    internalize(Mod, KernelSym);
+    ProteusPY_internalize(wrap(Mod.get()), KernelSym);
   }
 
   return wrap(Mod.release());


### PR DESCRIPTION
Problem:
The ordering in replay is incorrect. Currently, we do:
```
link()
prune()
internalize()
```

The correct order is: 
```
prune()
link()
internalize()
```

Solution will be to implement it in the correct order in the `ProteusPY_linkModules` function in `jit.cpp`