### PR TITLE
Improves robustness of random pipeline tuner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![docs (gh-pages)](https://github.com/Olympus-HPC/mneme/actions/workflows/gh-pages-docs.yml/badge.svg)](https://github.com/Olympus-HPC/mneme/actions/workflows/gh-pages-docs.yml)
+![License: Apache 2.0 with LLVM exceptions](https://img.shields.io/badge/license-Apache%202.0%20with%20LLVM%20exceptions-blue.svg)
+
+
 # Mneme (Μνήμη)  
 *Named after the Greek goddess of memory, preserves and replays the essence of your application's execution, allowing developers to revisit, analyze, and refine specific moments in code with precision.* 
 

--- a/docs/user/config.md
+++ b/docs/user/config.md
@@ -10,3 +10,4 @@ through environment variables that are applicable either at record time or at re
 | MNEME\_LOG\_LEVEL                | Recording|Replaying   | Log level of Mneme can take the values of (trace, debug, info, warn, error, critical, off)                                       | 
 | MNEME\_LOG\_DIR                  | Recording|Replaying   | The directory in which we will store results into                                                                                | 
 | MNEME\_RR\_KERNELS               | Recording             | A regex to be used to choose which kernels to recoding. Only kernels with matching names will be recorded                        | 
+| MNEME\_MAX\_RECORDINGS               | Recording             | An integer describing the maximum number of recordings we can do on the same kernel.                        | 

--- a/include/mneme/DeviceTraits.hpp
+++ b/include/mneme/DeviceTraits.hpp
@@ -312,7 +312,7 @@ template <> struct DeviceTraits<DeviceVendors::HIP> {
     return hipStreamDestroy(Stream);
   }
 
-  static constexpr uintptr_t getSuggestedAddr() { return 0x1538c7e00000; }
+  static constexpr uintptr_t getSuggestedAddr() { return 0x1534f7e00000; }
 
   static hipError_t deviceLaunchKernel(const void *function_address,
                                        dim3 numBlocks, dim3 dimBlocks,

--- a/include/mneme/MnemePageManager.hpp
+++ b/include/mneme/MnemePageManager.hpp
@@ -221,7 +221,7 @@ template <mneme::DeviceVendors VendorTypes>
 std::unique_ptr<PageManager<VendorTypes>>
 initializePageManager(int DeviceID, void *ReqAddr = nullptr,
                       uint64_t ActualSize = -1) {
-  const int MaxTries = 1;
+  const int MaxTries = 5;
   auto MinPageSize = mneme::DeviceTraits<VendorTypes>::getMinPageSize(DeviceID);
   if (ActualSize == -1)
     ActualSize = mneme::util::roundUp(
@@ -243,7 +243,7 @@ initializePageManager(int DeviceID, void *ReqAddr = nullptr,
         ActualSize, reinterpret_cast<void *>(ReqAddr), MinPageSize);
     Try++;
   }
-  LOG_INFO("... Reserved successfully Virtual Address {}", VA);
+  LOG_INFO("... Reserved Virtual Address {}", VA);
   return std::make_unique<PageManager<VendorTypes>>(ActualSize, MinPageSize, VA,
                                                     DeviceID);
 }

--- a/include/mneme/MnemeRecord.hpp
+++ b/include/mneme/MnemeRecord.hpp
@@ -281,7 +281,8 @@ public:
       if (DeviceID == -1) {
         origGetDeviceID(&DeviceID);
       }
-      PM = initializePageManager<VendorTypes>(DeviceID);
+      PM = initializePageManager<VendorTypes>(
+          DeviceID, (void *)MnemeDeviceRT::getSuggestedAddr());
       getGlobalAddresses();
     }
 
@@ -359,7 +360,8 @@ public:
         origGetDeviceID(&DeviceID);
       }
       LOG_DEBUG("Initializing system {}", arch);
-      PM = initializePageManager<VendorTypes>(DeviceID);
+      PM = initializePageManager<VendorTypes>(
+          DeviceID, (void *)MnemeDeviceRT::getSuggestedAddr());
       getGlobalAddresses();
     }
 

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -191,6 +191,8 @@ class KernelInstancesCollection {
   void *VAddr;
   uint64_t VASize;
   llvm::DenseMap<uint64_t, KernelInstance> Instances;
+  uint64_t NumRecords;
+  int MaxRecordings;
 
 public:
   llvm::json::Object toJSON(uint64_t StaticHash) const {
@@ -221,8 +223,10 @@ public:
   }
 
   KernelInstancesCollection(void *VAddr, uint64_t VASize,
-                            std::shared_ptr<KernelInfo> KInfo)
-      : VAddr(VAddr), VASize(VASize), KInfo(KInfo) {
+                            std::shared_ptr<KernelInfo> KInfo,
+                            int MaxRecordings)
+      : VAddr(VAddr), VASize(VASize), KInfo(KInfo),
+        MaxRecordings(MaxRecordings), NumRecords(0) {
     // Here I need to extract information regarding the kernel
     auto Func = KInfo->getExecutable().getKernelFunction(KInfo->Name);
     if (!Func)
@@ -268,6 +272,10 @@ public:
       dim3 &GridDim, dim3 &BlockDim, void **Args, size_t SharedMem,
       typename DeviceTraits<VendorTypes>::DeviceStream_t Stream,
       uint64_t StaticHash) {
+
+    if (NumRecords >= MaxRecordings)
+      return std::nullopt;
+
     auto DynamicHash = computeHash(GridDim, BlockDim, SharedMem, Args);
 
     if (Instances.contains(DynamicHash)) {
@@ -277,6 +285,8 @@ public:
           KInfo->getName(), DynamicHash);
       return std::nullopt;
     }
+
+    NumRecords++;
 
     LOG_DEBUG("First Instance of Kernel {} with DynamicHash {}, recording ...",
               KInfo->getName(), DynamicHash);
@@ -324,10 +334,10 @@ class RecordDatabase {
   std::string RegexStr;
   bool HasRegex;
   llvm::DenseMap<uint64_t, KernelInstancesCollection> KernelRecords;
+  uint64_t MaxRecordings;
 
 public:
   RecordDatabase() : KernelWhiteList(""), HasRegex(false) {
-    auto Dir = std::getenv("MNEME_DATA_DIR");
     auto WhiteList = std::getenv("MNEME_RR_KERNELS");
     if (WhiteList) {
       HasRegex = true;
@@ -335,6 +345,7 @@ public:
       KernelWhiteList = std::string(WhiteList);
     }
 
+    auto Dir = std::getenv("MNEME_DATA_DIR");
     MnemeDirectory =
         (Dir ? std::string(Dir) : std::filesystem::current_path().string());
 
@@ -343,6 +354,11 @@ public:
                                " does not exist.\n");
     }
     MnemeDirectory = std::filesystem::absolute(MnemeDirectory);
+    MaxRecordings = 4;
+    auto UMaxRecordings = std::getenv("MNEME_MAX_RECORDINGS");
+    if (UMaxRecordings) {
+      MaxRecordings = std::atoi(UMaxRecordings);
+    }
   }
 
   ~RecordDatabase() {
@@ -389,7 +405,7 @@ public:
 
     auto IT = KernelRecords.try_emplace(
         KInfo->getStaticHash(),
-        KernelInstancesCollection(VAddr, VASize, KInfo));
+        KernelInstancesCollection(VAddr, VASize, KInfo, MaxRecordings));
     return IT.first->second.takeSnapshot<VendorTypes>(
         MnemeDirectory, GlobalVars, DeviceMemory, GridDim, BlockDim, Args,
         SharedMem, Stream, KInfo->getStaticHash());

--- a/python/mneme/cli.py
+++ b/python/mneme/cli.py
@@ -48,7 +48,7 @@ def main():
     ReplayTuner.set_cli_args(p_tune)
 
     args = parser.parse_args()
-    args.func(args)
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/python/mneme/db.py
+++ b/python/mneme/db.py
@@ -65,6 +65,9 @@ class MnemeDB:
     def is_open(self):
         return self._open
 
+    def __len__(self):
+        return len(self._experiments)
+
     def open(self):
         if not self._dir.exists():
             self._dir.mkdir(parents=True, exist_ok=True)
@@ -102,8 +105,7 @@ class MnemeDB:
     def should_execute(self, exp: Experiment):
         _hash = exp.hash()
         if _hash in self._experiments:
-            return not self._experiments[_hash]
-
+            return False
         return True
 
     def suggest_ir_fn_name(self, exp: Experiment):
@@ -127,7 +129,6 @@ class MnemeDB:
         self._experiments[_hash] = exp.executed
 
     def save_ir(self, ir, _id):
-        fn = f"{str(self._dir)}/{self._static_hash}.{self._dynamic_hash}.{_id}.ll"
-        with open(fn, "w") as fd:
-            fd.write(ir)
+        fn = f"{str(self._dir)}/{self._static_hash}.{self._dynamic_hash}.{_id}.bc"
+        ir.to_bitcode(fn)
         return fn

--- a/python/mneme/llvm/module.py
+++ b/python/mneme/llvm/module.py
@@ -1,17 +1,17 @@
 from ctypes import (
-    c_char_p,
-    byref,
     POINTER,
+    byref,
     c_bool,
-    create_string_buffer,
+    c_char_p,
     c_size_t,
+    create_string_buffer,
     string_at,
 )
 
 from . import ffi
 from .common import _decode_string, _encode_string
-from .value import ValueRef, TypeRef
 from .context import get_global_context
+from .value import TypeRef, ValueRef
 
 
 def parse_assembly(llvmir, context=None):
@@ -201,6 +201,9 @@ class ModuleRef(ffi.ObjectRef):
     def clone(self):
         return ModuleRef(ffi.lib.LLVMPY_CloneModule(self), self._context)
 
+    def to_bitcode(self, fn: str):
+        ffi.lib.LLVMPY_WriteBitcode(self, _encode_string(fn))
+
 
 class _Iterator(ffi.ObjectRef):
     kind = None
@@ -372,3 +375,5 @@ ffi.lib.LLVMPY_SetModuleName.argtypes = [ffi.LLVMModuleRef, c_char_p]
 
 ffi.lib.LLVMPY_GetModuleSourceFileName.argtypes = [ffi.LLVMModuleRef]
 ffi.lib.LLVMPY_GetModuleSourceFileName.restype = c_char_p
+
+ffi.lib.LLVMPY_WriteBitcode.argtypes = [ffi.LLVMModuleRef, c_char_p]

--- a/python/mneme/replay_executor.py
+++ b/python/mneme/replay_executor.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import time
 from datetime import datetime
-from multiprocessing import Queue
+from multiprocessing import Event, Queue
 from typing import Tuple
 
 from mneme.db import MnemeDB
@@ -363,7 +363,7 @@ class CLIExecutor(BaseExecutor):
             exp.dump()
             exp, generated_ir = super()._execute(exp, ir_module, self.pipeline)
             if self._db is not None:
-                final = self._db.save_ir(str(generated_ir), exp.hash())
+                final = self._db.save_ir(generated_ir, exp.hash())
                 self._db.add(orig, final, exp)
             exp.dump()
             return
@@ -378,7 +378,7 @@ class CLIExecutor(BaseExecutor):
             exp, generated_ir = super()._execute(exp, ir_module.clone(), passes)
             if self._db is not None:
                 print(f"Hash of code is {exp.hash()}")
-                final = self._db.save_ir(str(generated_ir), exp.hash())
+                final = self._db.save_ir(generated_ir, exp.hash())
                 self._db.add(orig, final, exp)
             exp.dump()
 
@@ -401,7 +401,7 @@ class CLIExecutor(BaseExecutor):
                 executor.kernel_descr.dynamic_hash,
                 executor.db_suffix,
             ).open()
-            orig = executor._db.save_ir(str(root_ir), "orig")
+            orig = executor._db.save_ir(root_ir, "orig")
 
         with executor as Memory:
             exp = executor.get_experiment(executor.pipeline)
@@ -479,6 +479,7 @@ class TuneWorker(BaseExecutor):
         iterations: int,
         db_dir: str,
         suffix: str,
+        state: Event,
     ):
         # We need this to actually run things...
         fd_out = os.open(
@@ -507,6 +508,7 @@ class TuneWorker(BaseExecutor):
         ).open()
 
         with worker as Memory:
+            state.set()
             print("Starting busy loop")
             while True:
                 msg = request_q.get()
@@ -519,7 +521,7 @@ class TuneWorker(BaseExecutor):
                         msg["exp_id"],
                     )
                     exp, ir = worker.process_payload(root_ir.clone(), msg["data"])
-                    final = resdb.save_ir(str(ir), exp.hash())
+                    final = resdb.save_ir(ir, exp.hash())
                     response_q.put(
                         {
                             "exp_id": msg["exp_id"],

--- a/python/mneme/tuner.py
+++ b/python/mneme/tuner.py
@@ -4,7 +4,7 @@ import json
 import math
 import sys
 import threading
-from multiprocessing import Process, Queue
+from multiprocessing import Event, Process, Queue
 
 from mneme.db import MnemeDB
 from mneme.device import (
@@ -61,6 +61,7 @@ class TuneWorkerHandle:
         self.suffix = suffix
 
         # Start the subprocess and its monitor thread
+        self._state = None
         self._spawn_process()
         self.monitor_thread = threading.Thread(target=self._monitor)
         self.monitor_thread.start()
@@ -68,6 +69,7 @@ class TuneWorkerHandle:
 
     def _spawn_process(self):
         # Launch a fresh replay subprocess
+        self._state = Event()
         self.process = Process(
             target=TuneWorker.run,
             args=(
@@ -83,6 +85,7 @@ class TuneWorkerHandle:
                 self.iterations,
                 self.db_dir,
                 self.suffix,
+                self._state,
             ),
             daemon=False,
         )
@@ -93,6 +96,20 @@ class TuneWorkerHandle:
         while True:
             # Wait for subprocess to exit
             self.process.join()
+            if not self._state.is_set():
+                print("Event has not been set")
+                if self.current is not None:
+                    req = self.current
+                    req["payload"] = "exit"
+                    req["llvm_ir"] = ""
+                    req["exp_id"] = self.current["exp_id"]
+                    self.response_q.put(req)
+                else:
+                    req = dict()
+                    req["payload"] = "exit"
+                    self.response_q.put(req)
+                return
+
             exitcode = self.process.exitcode
 
             ## If shutdown requested, exit monitor
@@ -251,25 +268,29 @@ class ReplayTuner(BaseExecutor):
         )
         self.LLVMPassManager = PipelineManager()
 
-    def create_experiments(self, pipeline):
+    def create_experiments(self, pipeline, db):
         # NOTE: Some of the fields of the experiment are misguiding.
         # For example, the 'internalize' field is ignored, cause this
         # happens earlier regardless of the value of the field itself.
         # it jus exists to setup properly tracking of experiments.
-        experiments = [
-            Experiment(
-                specialize=self.specialize,
+        experiments = []
+        for spec in [True, False]:
+            exp = Experiment(
+                specialize=spec,
                 max_threads=0,
                 min_blocks_per_sm=0,
                 specialize_dims=self.specialize,
-                passes=self.LLVMPassManager.to_string(pipeline),
+                passes=pipeline,
                 prune=self.prune,
                 internalize=self.internalize,
                 codegen_opt=self.codegen_opt,
                 rtc=self.rtc,
                 device_arch=self.device_arch,
             )
-        ]
+            if not db.should_execute(exp):
+                print(f"Skippipng experiment {exp.hash()}")
+                continue
+            experiments.append(exp)
 
         max_threads = int(
             self.kernel_descr.block_dim.x
@@ -278,25 +299,28 @@ class ReplayTuner(BaseExecutor):
         )
 
         min_blocks_per_sm = [
-            i for i in range(0, int(math.ceil(1024 / max_threads)) + 1)
+            i for i in range(0, int(math.floor(1024 / max_threads)) + 1)
         ]
 
         # 0 indicates do not set launch bounds
         for mb in min_blocks_per_sm:
-            experiments.append(
-                Experiment(
-                    specialize=self.specialize,
+            for spec in [True, False]:
+                exp = Experiment(
+                    specialize=spec,
                     max_threads=max_threads,
                     min_blocks_per_sm=mb,
                     specialize_dims=self.specialize,
-                    passes=self.LLVMPassManager.to_string(pipeline),
+                    passes=pipeline,
                     prune=self.prune,
                     internalize=self.internalize,
                     codegen_opt=self.codegen_opt,
                     rtc=self.rtc,
                     device_arch=self.device_arch,
                 )
-            )
+                if not db.should_execute(exp):
+                    print(f"Skippipng experiment {exp.hash()}")
+                    continue
+                experiments.append(exp)
 
         return experiments
 
@@ -309,9 +333,9 @@ class ReplayTuner(BaseExecutor):
         executor = ReplayTuner(**kwargs)
         if tuner == "random":
             kwargs.pop("sampler")
-            ReplayTuner.run_random(executor)
+            return ReplayTuner.run_random(executor)
         elif tuner == "optuna":
-            ReplayTuner.run_optuna(executor)
+            return ReplayTuner.run_optuna(executor)
 
     @staticmethod
     def run_optuna(executor):
@@ -361,6 +385,8 @@ class ReplayTuner(BaseExecutor):
         for w in workers:
             w.join_monitor()
 
+        return 0
+
     @staticmethod
     def execute_list_of_experiments(
         orig, total_experiments, workers, completed_jobs_q, db, exp_id, start_id=0
@@ -409,7 +435,7 @@ class ReplayTuner(BaseExecutor):
                         raise RuntimeError(
                             "Expected llvm ir to exist on non failed experiment"
                         )
-                    db.add(orig, res["llvm_ir"], exp2)
+                db.add(orig, res["llvm_ir"], exp2)
                 print(
                     f"Worker {worker.idx} Done with {done_exp_id} had {exp2.failed} and took {exp2.exec_time}"
                 )
@@ -421,9 +447,15 @@ class ReplayTuner(BaseExecutor):
 
                     exp, exp_id = vals[0], vals[1]
                     in_flight[exp_id] = (exp, worker)
+            elif res["payload"] == "exit":
+                print("Return exit")
+                return -1
             else:
                 print("Unknown payload")
+                return -1
+
             sys.stdout.flush()
+        return 0
 
     @staticmethod
     def run_random(executor):
@@ -455,11 +487,13 @@ class ReplayTuner(BaseExecutor):
         )
 
         total_experiments = []
-
-        for p in passes:
-            experiments = executor.create_experiments(p)
-            for e in experiments:
-                total_experiments.append(e)
+        default_pipelines = [
+            "default<O1>",
+            "default<O2>",
+            "default<O3>",
+            "default<Os>",
+            "default<Oz>",
+        ]
 
         db = MnemeDB(
             executor.db_dir,
@@ -468,14 +502,28 @@ class ReplayTuner(BaseExecutor):
             executor.suffix,
         ).open()
 
-        root_ir = executor.link_ir()
-        orig = db.save_ir(str(root_ir), "orig")
+        print(f"Performed experiments {len(db)}")
 
-        ReplayTuner.execute_list_of_experiments(
+        for p in default_pipelines:
+            total_experiments += executor.create_experiments(p, db)
+
+        for p in passes:
+            total_experiments += executor.create_experiments(
+                executor.LLVMPassManager.to_string(p), db
+            )
+
+        root_ir = executor.link_ir()
+        orig = db.save_ir(root_ir, "orig")
+
+        ret = ReplayTuner.execute_list_of_experiments(
             orig, total_experiments, workers, completed_jobs_q, db, 0
         )
+
+        print(f"Mneme is done with code {ret}")
 
         for w in workers:
             w.shutdown_process()
         for w in workers:
             w.join_monitor()
+
+        return ret

--- a/src/python/device.cpp
+++ b/src/python/device.cpp
@@ -3,7 +3,6 @@
 #include <hip/hip_runtime_api.h>
 #include <llvm/Support/CBindingWrapping.h>
 #include <llvm/Support/MemoryBuffer.h>
-#include <mneme/MnemeLogger.hpp>
 #include <mneme/MnemePython.hpp>
 
 using namespace mneme;

--- a/src/python/llvm/bitcode.cpp
+++ b/src/python/llvm/bitcode.cpp
@@ -1,6 +1,7 @@
 #include "llvm-c/BitReader.h"
 #include <iostream>
 #include <llvm/IR/Module.h>
+#include <mneme/MnemeLogger.hpp>
 
 #include "core.h"
 

--- a/src/python/llvm/module.cpp
+++ b/src/python/llvm/module.cpp
@@ -2,17 +2,23 @@
 #include "core.h"
 #include "llvm-c/Analysis.h"
 #include "llvm-c/Core.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/TypeFinder.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include <clocale>
+#include <mneme/MnemeLogger.hpp>
 #include <string>
 
 /* An iterator around a module's globals, including the stop condition */
 struct GlobalsIterator {
-    typedef llvm::Module::global_iterator iterator;
-    iterator cur;
-    iterator end;
+  typedef llvm::Module::global_iterator iterator;
+  iterator cur;
+  iterator end;
 
-    GlobalsIterator(iterator cur, iterator end) : cur(cur), end(end) {}
+  GlobalsIterator(iterator cur, iterator end) : cur(cur), end(end) {}
 };
 
 struct OpaqueGlobalsIterator;
@@ -20,12 +26,12 @@ typedef OpaqueGlobalsIterator *LLVMGlobalsIteratorRef;
 
 /* An iterator around a module's functions, including the stop condition */
 struct FunctionsIterator {
-    typedef llvm::Module::const_iterator const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef llvm::Module::const_iterator const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    FunctionsIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  FunctionsIterator(const_iterator cur, const_iterator end)
+      : cur(cur), end(end) {}
 };
 
 struct OpaqueFunctionsIterator;
@@ -33,34 +39,33 @@ typedef OpaqueFunctionsIterator *LLVMFunctionsIteratorRef;
 
 /* module types iterator */
 class TypesIterator {
-  private:
-    llvm::TypeFinder finder;
-    using const_iterator = llvm::TypeFinder::const_iterator;
-    const_iterator cur;
+private:
+  llvm::TypeFinder finder;
+  using const_iterator = llvm::TypeFinder::const_iterator;
+  const_iterator cur;
 
-  public:
-    TypesIterator(llvm::Module &m, bool namedOnly)
-        : finder(llvm::TypeFinder()) {
-        finder.run(m, namedOnly);
-        cur = finder.begin();
+public:
+  TypesIterator(llvm::Module &m, bool namedOnly) : finder(llvm::TypeFinder()) {
+    finder.run(m, namedOnly);
+    cur = finder.begin();
+  }
+  const llvm::Type *next() {
+    if (cur != finder.end()) {
+      return *cur++;
     }
-    const llvm::Type *next() {
-        if (cur != finder.end()) {
-            return *cur++;
-        }
-        return nullptr;
-    }
+    return nullptr;
+  }
 };
 
 typedef TypesIterator *LLVMTypesIteratorRef;
 
 /* An iterator around a module's aliases, including the stop condition */
 struct AliasesIterator {
-    typedef llvm::Module::alias_iterator iterator;
-    iterator cur;
-    iterator end;
+  typedef llvm::Module::alias_iterator iterator;
+  iterator cur;
+  iterator end;
 
-    AliasesIterator(iterator cur, iterator end) : cur(cur), end(end) {}
+  AliasesIterator(iterator cur, iterator end) : cur(cur), end(end) {}
 };
 
 struct OpaqueAliasesIterator;
@@ -68,11 +73,11 @@ typedef OpaqueAliasesIterator *LLVMAliasesIteratorRef;
 
 /* An iterator around a module's ifuncs, including the stop condition */
 struct IFuncsIterator {
-    typedef llvm::Module::ifunc_iterator iterator;
-    iterator cur;
-    iterator end;
+  typedef llvm::Module::ifunc_iterator iterator;
+  iterator cur;
+  iterator end;
 
-    IFuncsIterator(iterator cur, iterator end) : cur(cur), end(end) {}
+  IFuncsIterator(iterator cur, iterator end) : cur(cur), end(end) {}
 };
 
 struct OpaqueIFuncsIterator;
@@ -85,43 +90,43 @@ typedef OpaqueIFuncsIterator *LLVMIFuncsIteratorRef;
 namespace llvm {
 
 static LLVMGlobalsIteratorRef wrap(GlobalsIterator *GI) {
-    return reinterpret_cast<LLVMGlobalsIteratorRef>(GI);
+  return reinterpret_cast<LLVMGlobalsIteratorRef>(GI);
 }
 
 static GlobalsIterator *unwrap(LLVMGlobalsIteratorRef GI) {
-    return reinterpret_cast<GlobalsIterator *>(GI);
+  return reinterpret_cast<GlobalsIterator *>(GI);
 }
 
 static LLVMFunctionsIteratorRef wrap(FunctionsIterator *GI) {
-    return reinterpret_cast<LLVMFunctionsIteratorRef>(GI);
+  return reinterpret_cast<LLVMFunctionsIteratorRef>(GI);
 }
 
 static FunctionsIterator *unwrap(LLVMFunctionsIteratorRef GI) {
-    return reinterpret_cast<FunctionsIterator *>(GI);
+  return reinterpret_cast<FunctionsIterator *>(GI);
 }
 
 static LLVMTypesIteratorRef wrap(TypesIterator *TyI) {
-    return reinterpret_cast<LLVMTypesIteratorRef>(TyI);
+  return reinterpret_cast<LLVMTypesIteratorRef>(TyI);
 }
 
 static TypesIterator *unwrap(LLVMTypesIteratorRef TyI) {
-    return reinterpret_cast<TypesIterator *>(TyI);
+  return reinterpret_cast<TypesIterator *>(TyI);
 }
 
 static LLVMAliasesIteratorRef wrap(AliasesIterator *TyI) {
-    return reinterpret_cast<LLVMAliasesIteratorRef>(TyI);
+  return reinterpret_cast<LLVMAliasesIteratorRef>(TyI);
 }
 
 static AliasesIterator *unwrap(LLVMAliasesIteratorRef TyI) {
-    return reinterpret_cast<AliasesIterator *>(TyI);
+  return reinterpret_cast<AliasesIterator *>(TyI);
 }
 
 static LLVMIFuncsIteratorRef wrap(IFuncsIterator *TyI) {
-    return reinterpret_cast<LLVMIFuncsIteratorRef>(TyI);
+  return reinterpret_cast<LLVMIFuncsIteratorRef>(TyI);
 }
 
 static IFuncsIterator *unwrap(LLVMIFuncsIteratorRef TyI) {
-    return reinterpret_cast<IFuncsIterator *>(TyI);
+  return reinterpret_cast<IFuncsIterator *>(TyI);
 }
 
 } // end namespace llvm
@@ -137,109 +142,109 @@ LLVMPY_DisposeModule(LLVMModuleRef m) { return LLVMDisposeModule(m); }
 
 API_EXPORT(void)
 LLVMPY_PrintModuleToString(LLVMModuleRef M, const char **outstr) {
-    // Change the locale to en_US before calling LLVM to print the module
-    // due to a LLVM bug https://llvm.org/bugs/show_bug.cgi?id=12906
-    char *old_locale = strdup(setlocale(LC_ALL, NULL));
-    setlocale(LC_ALL, "C");
+  // Change the locale to en_US before calling LLVM to print the module
+  // due to a LLVM bug https://llvm.org/bugs/show_bug.cgi?id=12906
+  char *old_locale = strdup(setlocale(LC_ALL, NULL));
+  setlocale(LC_ALL, "C");
 
-    *outstr = LLVMPrintModuleToString(M);
+  *outstr = LLVMPrintModuleToString(M);
 
-    // Revert locale
-    setlocale(LC_ALL, old_locale);
-    free(old_locale);
+  // Revert locale
+  setlocale(LC_ALL, old_locale);
+  free(old_locale);
 }
 
 API_EXPORT(const char *)
 LLVMPY_GetModuleSourceFileName(LLVMModuleRef M) {
-    return llvm::unwrap(M)->getSourceFileName().c_str();
+  return llvm::unwrap(M)->getSourceFileName().c_str();
 }
 
 API_EXPORT(const char *)
 LLVMPY_GetModuleName(LLVMModuleRef M) {
-    return llvm::unwrap(M)->getModuleIdentifier().c_str();
+  return llvm::unwrap(M)->getModuleIdentifier().c_str();
 }
 
 API_EXPORT(void)
 LLVMPY_SetModuleName(LLVMModuleRef M, const char *Name) {
-    llvm::unwrap(M)->setModuleIdentifier(Name);
+  llvm::unwrap(M)->setModuleIdentifier(Name);
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_GetNamedFunction(LLVMModuleRef M, const char *Name) {
-    return LLVMGetNamedFunction(M, Name);
+  return LLVMGetNamedFunction(M, Name);
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_GetNamedGlobalVariable(LLVMModuleRef M, const char *Name) {
-    using namespace llvm;
-    return wrap(unwrap(M)->getGlobalVariable(Name));
+  using namespace llvm;
+  return wrap(unwrap(M)->getGlobalVariable(Name));
 }
 
 API_EXPORT(LLVMTypeRef)
 LLVMPY_GetNamedStructType(LLVMModuleRef M, const char *Name) {
-    return LLVMGetTypeByName(M, Name);
+  return LLVMGetTypeByName(M, Name);
 }
 
 API_EXPORT(int)
 LLVMPY_VerifyModule(LLVMModuleRef M, char **OutMsg) {
-    return LLVMVerifyModule(M, LLVMReturnStatusAction, OutMsg);
+  return LLVMVerifyModule(M, LLVMReturnStatusAction, OutMsg);
 }
 
 API_EXPORT(void)
 LLVMPY_GetDataLayout(LLVMModuleRef M, const char **DL) {
-    *DL = LLVMGetDataLayoutStr(M);
+  *DL = LLVMGetDataLayoutStr(M);
 }
 
 API_EXPORT(void)
 LLVMPY_SetDataLayout(LLVMModuleRef M, const char *DL) {
-    LLVMSetDataLayout(M, DL);
+  LLVMSetDataLayout(M, DL);
 }
 
 API_EXPORT(void)
 LLVMPY_GetTarget(LLVMModuleRef M, const char **Triple) {
-    *Triple = LLVMGetTarget(M);
+  *Triple = LLVMGetTarget(M);
 }
 
 API_EXPORT(void)
 LLVMPY_SetTarget(LLVMModuleRef M, const char *Triple) {
-    LLVMSetTarget(M, Triple);
+  LLVMSetTarget(M, Triple);
 }
 
 // Iteration APIs
 
 API_EXPORT(LLVMGlobalsIteratorRef)
 LLVMPY_ModuleGlobalsIter(LLVMModuleRef M) {
-    using namespace llvm;
-    Module *mod = unwrap(M);
-    return wrap(new GlobalsIterator(mod->global_begin(), mod->global_end()));
+  using namespace llvm;
+  Module *mod = unwrap(M);
+  return wrap(new GlobalsIterator(mod->global_begin(), mod->global_end()));
 }
 
 API_EXPORT(LLVMFunctionsIteratorRef)
 LLVMPY_ModuleFunctionsIter(LLVMModuleRef M) {
-    using namespace llvm;
-    Module *mod = unwrap(M);
-    return wrap(new FunctionsIterator(mod->begin(), mod->end()));
+  using namespace llvm;
+  Module *mod = unwrap(M);
+  return wrap(new FunctionsIterator(mod->begin(), mod->end()));
 }
 
 API_EXPORT(LLVMTypesIteratorRef)
 LLVMPY_ModuleTypesIter(LLVMModuleRef M) {
-    llvm::Module *mod = llvm::unwrap(M);
-    auto *iter = new TypesIterator(*mod, false);
-    return llvm::wrap(iter);
+  llvm::Module *mod = llvm::unwrap(M);
+  auto *iter = new TypesIterator(*mod, false);
+  return llvm::wrap(iter);
 }
 
 API_EXPORT(LLVMAliasesIteratorRef)
 LLVMPY_ModuleAliasesIter(LLVMModuleRef M) {
-    llvm::Module *mod = llvm::unwrap(M);
-    auto *iter = new AliasesIterator(mod->alias_begin(), mod->alias_end());
-    return llvm::wrap(iter);
+  llvm::Module *mod = llvm::unwrap(M);
+  auto *iter = new AliasesIterator(mod->alias_begin(), mod->alias_end());
+  return llvm::wrap(iter);
 }
 
 API_EXPORT(LLVMIFuncsIteratorRef)
 LLVMPY_ModuleIFuncsIter(LLVMModuleRef M) {
-    llvm::Module *mod = llvm::unwrap(M);
-    auto *iter = new IFuncsIterator(mod->ifunc_begin(), mod->ifunc_end());
-    return llvm::wrap(iter);
+  llvm::Module *mod = llvm::unwrap(M);
+  auto *iter = new IFuncsIterator(mod->ifunc_begin(), mod->ifunc_end());
+  return llvm::wrap(iter);
 }
 
 /*
@@ -247,68 +252,87 @@ LLVMPY_ModuleIFuncsIter(LLVMModuleRef M) {
 */
 API_EXPORT(LLVMValueRef)
 LLVMPY_GlobalsIterNext(LLVMGlobalsIteratorRef GI) {
-    using namespace llvm;
-    GlobalsIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(&*iter->cur++);
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  GlobalsIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(&*iter->cur++);
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_FunctionsIterNext(LLVMFunctionsIteratorRef GI) {
-    using namespace llvm;
-    FunctionsIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(&*iter->cur++);
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  FunctionsIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(&*iter->cur++);
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMTypeRef)
 LLVMPY_TypesIterNext(LLVMTypesIteratorRef TyI) {
-    return llvm::wrap(llvm::unwrap(TyI)->next());
+  return llvm::wrap(llvm::unwrap(TyI)->next());
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_AliasesIterNext(LLVMAliasesIteratorRef GI) {
-    using namespace llvm;
-    AliasesIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(&*iter->cur++);
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  AliasesIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(&*iter->cur++);
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_IFuncsIterNext(LLVMIFuncsIteratorRef GI) {
-    using namespace llvm;
-    IFuncsIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(&*iter->cur++);
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  IFuncsIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(&*iter->cur++);
+  } else {
+    return NULL;
+  }
+}
+
+API_EXPORT(void)
+LLVMPY_WriteBitcode(LLVMModuleRef ModRef, const char *Filename) {
+
+  // Open the file for writing.
+  std::error_code EC;
+  auto *Mod = llvm::unwrap(ModRef);
+  llvm::raw_fd_ostream Out(Filename, EC, llvm::sys::fs::OF_None);
+  if (EC)
+    LOG_FATAL("Got Error when storing Module\nEC:{}", EC.message());
+
+  // Emit the module.
+  llvm::WriteBitcodeToFile(*Mod, Out);
+  Out.flush(); // Ensure everything is written.
+
+  return;
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeGlobalsIter(LLVMGlobalsIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeFunctionsIter(LLVMFunctionsIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeTypesIter(LLVMTypesIteratorRef TyI) { delete llvm::unwrap(TyI); }
 
 API_EXPORT(void)
-LLVMPY_DisposeAliasesIter(LLVMAliasesIteratorRef GI) { delete llvm::unwrap(GI); }
+LLVMPY_DisposeAliasesIter(LLVMAliasesIteratorRef GI) {
+  delete llvm::unwrap(GI);
+}
 
 API_EXPORT(void)
 LLVMPY_DisposeIFuncsIter(LLVMIFuncsIteratorRef GI) { delete llvm::unwrap(GI); }

--- a/src/python/llvm/value.cpp
+++ b/src/python/llvm/value.cpp
@@ -13,12 +13,11 @@
 
 /* An iterator around a function's blocks, including the stop condition */
 struct BlocksIterator {
-    typedef llvm::Function::const_iterator const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef llvm::Function::const_iterator const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    BlocksIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  BlocksIterator(const_iterator cur, const_iterator end) : cur(cur), end(end) {}
 };
 
 struct OpaqueBlocksIterator;
@@ -26,12 +25,12 @@ typedef OpaqueBlocksIterator *LLVMBlocksIteratorRef;
 
 /* An iterator around a function's arguments, including the stop condition */
 struct ArgumentsIterator {
-    typedef llvm::Function::const_arg_iterator const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef llvm::Function::const_arg_iterator const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    ArgumentsIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  ArgumentsIterator(const_iterator cur, const_iterator end)
+      : cur(cur), end(end) {}
 };
 
 struct OpaqueArgumentsIterator;
@@ -40,12 +39,12 @@ typedef OpaqueArgumentsIterator *LLVMArgumentsIteratorRef;
 /* An iterator around a basic block's instructions, including the stop condition
  */
 struct InstructionsIterator {
-    typedef llvm::BasicBlock::const_iterator const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef llvm::BasicBlock::const_iterator const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    InstructionsIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  InstructionsIterator(const_iterator cur, const_iterator end)
+      : cur(cur), end(end) {}
 };
 
 struct OpaqueInstructionsIterator;
@@ -53,24 +52,24 @@ typedef OpaqueInstructionsIterator *LLVMInstructionsIteratorRef;
 
 /* An iterator around a instruction's operands, including the stop condition */
 struct OperandsIterator {
-    typedef llvm::Instruction::const_op_iterator const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef llvm::Instruction::const_op_iterator const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    OperandsIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  OperandsIterator(const_iterator cur, const_iterator end)
+      : cur(cur), end(end) {}
 };
 
 struct OpaqueOperandsIterator;
 typedef OpaqueOperandsIterator *LLVMOperandsIteratorRef;
 
 struct ConstantDataIterator {
-    llvm::ConstantDataSequential *DS;
-    int current_index = 0;
-    int last_index = -1;
+  llvm::ConstantDataSequential *DS;
+  int current_index = 0;
+  int last_index = -1;
 
-    ConstantDataIterator(llvm::ConstantDataSequential *data)
-        : DS(data), current_index(0), last_index(DS->getNumElements()) {}
+  ConstantDataIterator(llvm::ConstantDataSequential *data)
+      : DS(data), current_index(0), last_index(DS->getNumElements()) {}
 };
 
 struct ConstantDataIterator;
@@ -79,12 +78,12 @@ typedef ConstantDataIterator *LLVMConstantDataIteratorRef;
 /* An iterator around a phi node's incoming blocks, including the stop condition
  */
 struct IncomingBlocksIterator {
-    typedef llvm::PHINode::const_block_iterator const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef llvm::PHINode::const_block_iterator const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    IncomingBlocksIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  IncomingBlocksIterator(const_iterator cur, const_iterator end)
+      : cur(cur), end(end) {}
 };
 
 struct OpaqueIncomingBlocksIterator;
@@ -92,12 +91,12 @@ typedef OpaqueIncomingBlocksIterator *LLVMIncomingBlocksIteratorRef;
 
 /* An iterator around a instruction's operands, including the stop condition */
 struct IndicesIterator {
-    typedef const unsigned *const_iterator;
-    const_iterator cur;
-    const_iterator end;
+  typedef const unsigned *const_iterator;
+  const_iterator cur;
+  const_iterator end;
 
-    IndicesIterator(const_iterator cur, const_iterator end)
-        : cur(cur), end(end) {}
+  IndicesIterator(const_iterator cur, const_iterator end)
+      : cur(cur), end(end) {}
 };
 
 struct OpaqueIndicesIterator;
@@ -106,59 +105,59 @@ typedef OpaqueIndicesIterator *LLVMIndicesIteratorRef;
 namespace llvm {
 
 static LLVMBlocksIteratorRef wrap(BlocksIterator *GI) {
-    return reinterpret_cast<LLVMBlocksIteratorRef>(GI);
+  return reinterpret_cast<LLVMBlocksIteratorRef>(GI);
 }
 
 static BlocksIterator *unwrap(LLVMBlocksIteratorRef GI) {
-    return reinterpret_cast<BlocksIterator *>(GI);
+  return reinterpret_cast<BlocksIterator *>(GI);
 }
 
 static LLVMArgumentsIteratorRef wrap(ArgumentsIterator *GI) {
-    return reinterpret_cast<LLVMArgumentsIteratorRef>(GI);
+  return reinterpret_cast<LLVMArgumentsIteratorRef>(GI);
 }
 
 static ArgumentsIterator *unwrap(LLVMArgumentsIteratorRef GI) {
-    return reinterpret_cast<ArgumentsIterator *>(GI);
+  return reinterpret_cast<ArgumentsIterator *>(GI);
 }
 
 static LLVMInstructionsIteratorRef wrap(InstructionsIterator *GI) {
-    return reinterpret_cast<LLVMInstructionsIteratorRef>(GI);
+  return reinterpret_cast<LLVMInstructionsIteratorRef>(GI);
 }
 
 static InstructionsIterator *unwrap(LLVMInstructionsIteratorRef GI) {
-    return reinterpret_cast<InstructionsIterator *>(GI);
+  return reinterpret_cast<InstructionsIterator *>(GI);
 }
 
 static LLVMOperandsIteratorRef wrap(OperandsIterator *GI) {
-    return reinterpret_cast<LLVMOperandsIteratorRef>(GI);
+  return reinterpret_cast<LLVMOperandsIteratorRef>(GI);
 }
 
 static OperandsIterator *unwrap(LLVMOperandsIteratorRef GI) {
-    return reinterpret_cast<OperandsIterator *>(GI);
+  return reinterpret_cast<OperandsIterator *>(GI);
 }
 
 static LLVMConstantDataIteratorRef wrap(ConstantDataIterator *CDI) {
-    return reinterpret_cast<LLVMConstantDataIteratorRef>(CDI);
+  return reinterpret_cast<LLVMConstantDataIteratorRef>(CDI);
 }
 
 static ConstantDataIterator *unwrap(LLVMConstantDataIteratorRef CDI) {
-    return reinterpret_cast<ConstantDataIterator *>(CDI);
+  return reinterpret_cast<ConstantDataIterator *>(CDI);
 }
 
 static LLVMIncomingBlocksIteratorRef wrap(IncomingBlocksIterator *GI) {
-    return reinterpret_cast<LLVMIncomingBlocksIteratorRef>(GI);
+  return reinterpret_cast<LLVMIncomingBlocksIteratorRef>(GI);
 }
 
 static IncomingBlocksIterator *unwrap(LLVMIncomingBlocksIteratorRef GI) {
-    return reinterpret_cast<IncomingBlocksIterator *>(GI);
+  return reinterpret_cast<IncomingBlocksIterator *>(GI);
 }
 
 static LLVMIndicesIteratorRef wrap(IndicesIterator *GI) {
-    return reinterpret_cast<LLVMIndicesIteratorRef>(GI);
+  return reinterpret_cast<LLVMIndicesIteratorRef>(GI);
 }
 
 static IndicesIterator *unwrap(LLVMIndicesIteratorRef GI) {
-    return reinterpret_cast<IndicesIterator *>(GI);
+  return reinterpret_cast<IndicesIterator *>(GI);
 }
 
 } // namespace llvm
@@ -167,139 +166,139 @@ extern "C" {
 
 API_EXPORT(LLVMBlocksIteratorRef)
 LLVMPY_FunctionBlocksIter(LLVMValueRef F) {
-    using namespace llvm;
-    Function *func = unwrap<Function>(F);
-    return wrap(new BlocksIterator(func->begin(), func->end()));
+  using namespace llvm;
+  Function *func = unwrap<Function>(F);
+  return wrap(new BlocksIterator(func->begin(), func->end()));
 }
 
 API_EXPORT(LLVMArgumentsIteratorRef)
 LLVMPY_FunctionArgumentsIter(LLVMValueRef F) {
-    using namespace llvm;
-    Function *func = unwrap<Function>(F);
-    return wrap(new ArgumentsIterator(func->arg_begin(), func->arg_end()));
+  using namespace llvm;
+  Function *func = unwrap<Function>(F);
+  return wrap(new ArgumentsIterator(func->arg_begin(), func->arg_end()));
 }
 
 API_EXPORT(LLVMInstructionsIteratorRef)
 LLVMPY_BlockInstructionsIter(LLVMValueRef B) {
-    using namespace llvm;
-    BasicBlock *block = unwrap<BasicBlock>(B);
-    return wrap(new InstructionsIterator(block->begin(), block->end()));
+  using namespace llvm;
+  BasicBlock *block = unwrap<BasicBlock>(B);
+  return wrap(new InstructionsIterator(block->begin(), block->end()));
 }
 
 API_EXPORT(LLVMOperandsIteratorRef)
 LLVMPY_OperandsIter(LLVMValueRef I) {
-    using namespace llvm;
-    User *user = unwrap<User>(I);
-    return wrap(new OperandsIterator(user->op_begin(), user->op_end()));
+  using namespace llvm;
+  User *user = unwrap<User>(I);
+  return wrap(new OperandsIterator(user->op_begin(), user->op_end()));
 }
 
 API_EXPORT(LLVMConstantDataIteratorRef)
 LLVMPY_ConstantDataIter(LLVMValueRef I) {
-    using namespace llvm;
-    Value *val = unwrap<Value>(I);
-    if (llvm::ConstantDataSequential *cds =
-            llvm::dyn_cast<llvm::ConstantDataSequential>(val)) {
-        // You can safely use cds as a ConstantDataSequential
-        return wrap(new ConstantDataIterator(cds));
-    }
-    return nullptr;
+  using namespace llvm;
+  Value *val = unwrap<Value>(I);
+  if (llvm::ConstantDataSequential *cds =
+          llvm::dyn_cast<llvm::ConstantDataSequential>(val)) {
+    // You can safely use cds as a ConstantDataSequential
+    return wrap(new ConstantDataIterator(cds));
+  }
+  return nullptr;
 }
 
 API_EXPORT(LLVMIncomingBlocksIteratorRef)
 LLVMPY_PhiIncomingBlocksIter(LLVMValueRef I) {
-    using namespace llvm;
-    PHINode *inst = unwrap<PHINode>(I);
-    return wrap(
-        new IncomingBlocksIterator(inst->block_begin(), inst->block_end()));
+  using namespace llvm;
+  PHINode *inst = unwrap<PHINode>(I);
+  return wrap(
+      new IncomingBlocksIterator(inst->block_begin(), inst->block_end()));
 }
 
 API_EXPORT(LLVMIndicesIteratorRef)
 LLVMPY_IndicesIter(LLVMValueRef I) {
-    if (llvm::InsertValueInst *CI =
-            llvm::dyn_cast<llvm::InsertValueInst>((llvm::Value *)I)) {
-        return llvm::wrap(new IndicesIterator(CI->idx_begin(), CI->idx_end()));
-    }
-    if (llvm::ExtractValueInst *CI =
-            llvm::dyn_cast<llvm::ExtractValueInst>((llvm::Value *)I)) {
-        return llvm::wrap(new IndicesIterator(CI->idx_begin(), CI->idx_end()));
-    }
-    return nullptr;
+  if (llvm::InsertValueInst *CI =
+          llvm::dyn_cast<llvm::InsertValueInst>((llvm::Value *)I)) {
+    return llvm::wrap(new IndicesIterator(CI->idx_begin(), CI->idx_end()));
+  }
+  if (llvm::ExtractValueInst *CI =
+          llvm::dyn_cast<llvm::ExtractValueInst>((llvm::Value *)I)) {
+    return llvm::wrap(new IndicesIterator(CI->idx_begin(), CI->idx_end()));
+  }
+  return nullptr;
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_BlocksIterNext(LLVMBlocksIteratorRef GI) {
-    using namespace llvm;
-    BlocksIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(static_cast<const Value *>(&*iter->cur++));
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  BlocksIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(static_cast<const Value *>(&*iter->cur++));
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_ArgumentsIterNext(LLVMArgumentsIteratorRef GI) {
-    using namespace llvm;
-    ArgumentsIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(&*iter->cur++);
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  ArgumentsIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(&*iter->cur++);
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_InstructionsIterNext(LLVMInstructionsIteratorRef GI) {
-    using namespace llvm;
-    InstructionsIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(&*iter->cur++);
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  InstructionsIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(&*iter->cur++);
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_OperandsIterNext(LLVMOperandsIteratorRef GI) {
-    using namespace llvm;
-    OperandsIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap((&*iter->cur++)->get());
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  OperandsIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap((&*iter->cur++)->get());
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_ConstantDataIterNext(LLVMConstantDataIteratorRef CDI) {
-    using namespace llvm;
-    ConstantDataIterator *iter = unwrap(CDI);
-    if (iter->current_index == iter->last_index)
-        return NULL;
-    return wrap(static_cast<const Value *>(
-        iter->DS->getElementAsConstant(iter->current_index++)));
+  using namespace llvm;
+  ConstantDataIterator *iter = unwrap(CDI);
+  if (iter->current_index == iter->last_index)
+    return NULL;
+  return wrap(static_cast<const Value *>(
+      iter->DS->getElementAsConstant(iter->current_index++)));
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_IncomingBlocksIterNext(LLVMIncomingBlocksIteratorRef GI) {
-    using namespace llvm;
-    IncomingBlocksIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return wrap(static_cast<const Value *>(*iter->cur++));
-    } else {
-        return NULL;
-    }
+  using namespace llvm;
+  IncomingBlocksIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return wrap(static_cast<const Value *>(*iter->cur++));
+  } else {
+    return NULL;
+  }
 }
 
 API_EXPORT(int64_t)
 LLVMPY_IndicesIterNext(LLVMIndicesIteratorRef GI) {
-    using namespace llvm;
-    IndicesIterator *iter = unwrap(GI);
-    if (iter->cur != iter->end) {
-        return *iter->cur++;
-    } else {
-        return int64_t(-1);
-    }
+  using namespace llvm;
+  IndicesIterator *iter = unwrap(GI);
+  if (iter->cur != iter->end) {
+    return *iter->cur++;
+  } else {
+    return int64_t(-1);
+  }
 }
 
 API_EXPORT(void)
@@ -307,32 +306,32 @@ LLVMPY_DisposeBlocksIter(LLVMBlocksIteratorRef GI) { delete llvm::unwrap(GI); }
 
 API_EXPORT(void)
 LLVMPY_DisposeArgumentsIter(LLVMArgumentsIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeInstructionsIter(LLVMInstructionsIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeOperandsIter(LLVMOperandsIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeConstantDataIter(LLVMConstantDataIteratorRef DGI) {
-    delete llvm::unwrap(DGI);
+  delete llvm::unwrap(DGI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeIncomingBlocksIter(LLVMIncomingBlocksIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(void)
 LLVMPY_DisposeIndicesIter(LLVMIndicesIteratorRef GI) {
-    delete llvm::unwrap(GI);
+  delete llvm::unwrap(GI);
 }
 
 API_EXPORT(bool)
@@ -340,106 +339,106 @@ LLVMPY_IsConstant(LLVMValueRef Val) { return LLVMIsConstant(Val); }
 
 API_EXPORT(const uint64_t *)
 LLVMPY_GetConstantIntRawValue(LLVMValueRef Val, bool *littleEndian) {
-    if (littleEndian) {
-        *littleEndian = llvm::sys::IsLittleEndianHost;
-    }
-    if (llvm::ConstantInt *CI =
-            llvm::dyn_cast<llvm::ConstantInt>((llvm::Value *)Val)) {
-        return CI->getValue().getRawData();
-    }
-    return nullptr;
+  if (littleEndian) {
+    *littleEndian = llvm::sys::IsLittleEndianHost;
+  }
+  if (llvm::ConstantInt *CI =
+          llvm::dyn_cast<llvm::ConstantInt>((llvm::Value *)Val)) {
+    return CI->getValue().getRawData();
+  }
+  return nullptr;
 }
 
 API_EXPORT(unsigned)
 LLVMPY_GetConstantIntNumWords(LLVMValueRef Val) {
-    if (llvm::ConstantInt *CI =
-            llvm::dyn_cast<llvm::ConstantInt>((llvm::Value *)Val)) {
-        return CI->getValue().getNumWords();
-    }
-    return 0;
+  if (llvm::ConstantInt *CI =
+          llvm::dyn_cast<llvm::ConstantInt>((llvm::Value *)Val)) {
+    return CI->getValue().getNumWords();
+  }
+  return 0;
 }
 
 API_EXPORT(uint64_t)
 LLVMPY_GetAlignment(LLVMValueRef Val) {
-    llvm::Value *unwrapped = llvm::unwrap(Val);
-    llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(unwrapped);
-    if (auto *loadInst = llvm::dyn_cast<llvm::LoadInst>(inst)) {
-        return loadInst->getAlign().value();
-    } else if (auto *storeInst = llvm::dyn_cast<llvm::StoreInst>(inst)) {
-        return storeInst->getAlign().value();
-    } else if (auto *allocaInst = llvm::dyn_cast<llvm::AllocaInst>(inst)) {
-        return allocaInst->getAlign().value();
-    }
+  llvm::Value *unwrapped = llvm::unwrap(Val);
+  llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(unwrapped);
+  if (auto *loadInst = llvm::dyn_cast<llvm::LoadInst>(inst)) {
+    return loadInst->getAlign().value();
+  } else if (auto *storeInst = llvm::dyn_cast<llvm::StoreInst>(inst)) {
+    return storeInst->getAlign().value();
+  } else if (auto *allocaInst = llvm::dyn_cast<llvm::AllocaInst>(inst)) {
+    return allocaInst->getAlign().value();
+  }
 
-    return 0;
+  return 0;
 }
 
 API_EXPORT(double)
 LLVMPY_GetConstantFPValue(LLVMValueRef Val, bool *losesInfo) {
-    LLVMBool losesInfo_internal;
-    double result = LLVMConstRealGetDouble(Val, &losesInfo_internal);
-    if (losesInfo) {
-        *losesInfo = losesInfo_internal;
-    }
-    return result;
+  LLVMBool losesInfo_internal;
+  double result = LLVMConstRealGetDouble(Val, &losesInfo_internal);
+  if (losesInfo) {
+    *losesInfo = losesInfo_internal;
+  }
+  return result;
 }
 
 API_EXPORT(const char *)
 LLVMPY_GetConstantDataAsString(LLVMValueRef Val) {
-    if (llvm::ConstantDataSequential *CI =
-            llvm::dyn_cast<llvm::ConstantDataSequential>((llvm::Value *)Val)) {
-        if (!CI->isString())
-            return nullptr;
-        auto str = CI->getAsString();
-        return LLVMPY_CreateByteString((const char *)str.bytes_begin(),
-                                       str.bytes_end() - str.bytes_begin());
-    }
-    return nullptr;
+  if (llvm::ConstantDataSequential *CI =
+          llvm::dyn_cast<llvm::ConstantDataSequential>((llvm::Value *)Val)) {
+    if (!CI->isString())
+      return nullptr;
+    auto str = CI->getAsString();
+    return LLVMPY_CreateByteString((const char *)str.bytes_begin(),
+                                   str.bytes_end() - str.bytes_begin());
+  }
+  return nullptr;
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_GetConstantSequenceElement(LLVMValueRef Val, unsigned i) {
-    if (llvm::ConstantDataSequential *CI =
-            llvm::dyn_cast<llvm::ConstantDataSequential>((llvm::Value *)Val)) {
-        return LLVMValueRef(CI->getElementAsConstant(i));
-    }
-    return nullptr;
+  if (llvm::ConstantDataSequential *CI =
+          llvm::dyn_cast<llvm::ConstantDataSequential>((llvm::Value *)Val)) {
+    return LLVMValueRef(CI->getElementAsConstant(i));
+  }
+  return nullptr;
 }
 
 API_EXPORT(size_t)
 LLVMPY_GetConstantSequenceNumElements(LLVMValueRef Val) {
-    if (llvm::ConstantDataSequential *CI =
-            llvm::dyn_cast<llvm::ConstantDataSequential>((llvm::Value *)Val)) {
-        return CI->getNumElements();
-    }
-    return 0;
+  if (llvm::ConstantDataSequential *CI =
+          llvm::dyn_cast<llvm::ConstantDataSequential>((llvm::Value *)Val)) {
+    return CI->getNumElements();
+  }
+  return 0;
 }
 
 API_EXPORT(bool)
 LLVMPY_HasInitializer(LLVMValueRef Val) {
-    if (llvm::GlobalVariable *CI =
-            llvm::dyn_cast<llvm::GlobalVariable>((llvm::Value *)Val)) {
-        return CI->hasInitializer();
-    }
-    return false;
+  if (llvm::GlobalVariable *CI =
+          llvm::dyn_cast<llvm::GlobalVariable>((llvm::Value *)Val)) {
+    return CI->hasInitializer();
+  }
+  return false;
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_GetInitializer(LLVMValueRef Val) {
-    if (llvm::GlobalVariable *CI =
-            llvm::dyn_cast<llvm::GlobalVariable>((llvm::Value *)Val)) {
-        return LLVMValueRef(CI->getInitializer());
-    }
-    return nullptr;
+  if (llvm::GlobalVariable *CI =
+          llvm::dyn_cast<llvm::GlobalVariable>((llvm::Value *)Val)) {
+    return LLVMValueRef(CI->getInitializer());
+  }
+  return nullptr;
 }
 
 API_EXPORT(LLVMValueRef)
 LLVMPY_ConstantExprAsInstruction(LLVMValueRef Val) {
-    if (llvm::ConstantExpr *CI =
-            llvm::dyn_cast<llvm::ConstantExpr>((llvm::Value *)Val)) {
-        return LLVMValueRef(CI->getAsInstruction());
-    }
-    return nullptr;
+  if (llvm::ConstantExpr *CI =
+          llvm::dyn_cast<llvm::ConstantExpr>((llvm::Value *)Val)) {
+    return LLVMValueRef(CI->getAsInstruction());
+  }
+  return nullptr;
 }
 
 API_EXPORT(int)
@@ -447,7 +446,7 @@ LLVMPY_GetValueKind(LLVMValueRef Val) { return (int)LLVMGetValueKind(Val); }
 
 API_EXPORT(void)
 LLVMPY_PrintValueToString(LLVMValueRef Val, const char **outstr) {
-    *outstr = LLVMPrintValueToString(Val);
+  *outstr = LLVMPrintValueToString(Val);
 }
 
 API_EXPORT(const char *)
@@ -455,7 +454,7 @@ LLVMPY_GetValueName(LLVMValueRef Val) { return LLVMGetValueName(Val); }
 
 API_EXPORT(void)
 LLVMPY_SetValueName(LLVMValueRef Val, const char *Name) {
-    LLVMSetValueName(Val, Name);
+  LLVMSetValueName(Val, Name);
 }
 
 API_EXPORT(LLVMModuleRef)
@@ -463,7 +462,7 @@ LLVMPY_GetGlobalParent(LLVMValueRef Val) { return LLVMGetGlobalParent(Val); }
 
 API_EXPORT(void)
 LLVMPY_SetLinkage(LLVMValueRef Val, int Linkage) {
-    LLVMSetLinkage(Val, (LLVMLinkage)Linkage);
+  LLVMSetLinkage(Val, (LLVMLinkage)Linkage);
 }
 
 API_EXPORT(int)
@@ -471,7 +470,7 @@ LLVMPY_GetLinkage(LLVMValueRef Val) { return (int)LLVMGetLinkage(Val); }
 
 API_EXPORT(void)
 LLVMPY_SetVisibility(LLVMValueRef Val, int Visibility) {
-    LLVMSetVisibility(Val, (LLVMVisibility)Visibility);
+  LLVMSetVisibility(Val, (LLVMVisibility)Visibility);
 }
 
 API_EXPORT(int)
@@ -479,12 +478,12 @@ LLVMPY_GetVisibility(LLVMValueRef Val) { return (int)LLVMGetVisibility(Val); }
 
 API_EXPORT(void)
 LLVMPY_SetDLLStorageClass(LLVMValueRef Val, int DLLStorageClass) {
-    LLVMSetDLLStorageClass(Val, (LLVMDLLStorageClass)DLLStorageClass);
+  LLVMSetDLLStorageClass(Val, (LLVMDLLStorageClass)DLLStorageClass);
 }
 
 API_EXPORT(int)
 LLVMPY_GetDLLStorageClass(LLVMValueRef Val) {
-    return (int)LLVMGetDLLStorageClass(Val);
+  return (int)LLVMGetDLLStorageClass(Val);
 }
 
 API_EXPORT(int)
@@ -492,44 +491,44 @@ LLVMPY_IsDeclaration(LLVMValueRef GV) { return LLVMIsDeclaration(GV); }
 
 API_EXPORT(void)
 LLVMPY_WriteCFG(LLVMValueRef Fval, const char **OutStr, int ShowInst) {
-    using namespace llvm;
-    Function *F = unwrap<Function>(Fval);
-    std::string buffer;
-    raw_string_ostream stream(buffer);
-    DOTFuncInfo CFGInfo(F, nullptr, nullptr, 0);
-    WriteGraph(stream, &CFGInfo, !ShowInst, F->getName());
-    *OutStr = LLVMPY_CreateString(stream.str().c_str());
+  using namespace llvm;
+  Function *F = unwrap<Function>(Fval);
+  std::string buffer;
+  raw_string_ostream stream(buffer);
+  DOTFuncInfo CFGInfo(F, nullptr, nullptr, 0);
+  WriteGraph(stream, &CFGInfo, !ShowInst, F->getName());
+  *OutStr = LLVMPY_CreateString(stream.str().c_str());
 }
 
 API_EXPORT(const char *)
 LLVMPY_GetOpcodeName(LLVMValueRef Val) {
-    // try to convert to an instruction value, works for other derived
-    // types too
-    llvm::Value *unwrapped = llvm::unwrap(Val);
-    llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(unwrapped);
-    if (inst) {
-        return LLVMPY_CreateString(inst->getOpcodeName());
-    }
-    return LLVMPY_CreateString("");
+  // try to convert to an instruction value, works for other derived
+  // types too
+  llvm::Value *unwrapped = llvm::unwrap(Val);
+  llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(unwrapped);
+  if (inst) {
+    return LLVMPY_CreateString(inst->getOpcodeName());
+  }
+  return LLVMPY_CreateString("");
 }
 
 API_EXPORT(LLVMTypeRef)
 LLVMPY_TypeOfMemory(LLVMValueRef Val) {
-    llvm::Value *unwrapped = llvm::unwrap(Val);
-    if (auto *inst = llvm::dyn_cast<llvm::Instruction>(unwrapped)) {
-        if (auto *SI = llvm::dyn_cast<llvm::StoreInst>(inst)) {
-            return LLVMTypeRef(SI->getValueOperand()->getType());
-        } else if (auto *LI = llvm::dyn_cast<llvm::LoadInst>(inst)) {
-            return LLVMTypeRef(LI->getType());
-        } else if (auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(inst)) {
-            return LLVMTypeRef(GEP->getSourceElementType());
-        } else if (auto AC = llvm::dyn_cast<llvm::AllocaInst>(inst)) {
-            return LLVMTypeRef(AC->getAllocatedType());
-        }
-    } else if (auto *F = llvm::dyn_cast<llvm::Function>(unwrapped)) {
-        return LLVMTypeRef(F->getFunctionType());
+  llvm::Value *unwrapped = llvm::unwrap(Val);
+  if (auto *inst = llvm::dyn_cast<llvm::Instruction>(unwrapped)) {
+    if (auto *SI = llvm::dyn_cast<llvm::StoreInst>(inst)) {
+      return LLVMTypeRef(SI->getValueOperand()->getType());
+    } else if (auto *LI = llvm::dyn_cast<llvm::LoadInst>(inst)) {
+      return LLVMTypeRef(LI->getType());
+    } else if (auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(inst)) {
+      return LLVMTypeRef(GEP->getSourceElementType());
+    } else if (auto AC = llvm::dyn_cast<llvm::AllocaInst>(inst)) {
+      return LLVMTypeRef(AC->getAllocatedType());
     }
-    return NULL;
+  } else if (auto *F = llvm::dyn_cast<llvm::Function>(unwrapped)) {
+    return LLVMTypeRef(F->getFunctionType());
+  }
+  return NULL;
 }
 
 } // end extern "C"

--- a/tests/record/test_block_grid_1d.cpp
+++ b/tests/record/test_block_grid_1d.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_1d%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_1d%ext | %FILECHECK %s --check-prefixes=CHECK
 // RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
 // RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
 // clang-format on

--- a/tests/record/test_block_grid_2d.cpp
+++ b/tests/record/test_block_grid_2d.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_2d%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_2d%ext | %FILECHECK %s --check-prefixes=CHECK
 // RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
 // RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
 // clang-format on

--- a/tests/record/test_block_grid_3d.cpp
+++ b/tests/record/test_block_grid_3d.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_3d%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_3d%ext | %FILECHECK %s --check-prefixes=CHECK
 // RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
 // RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
 // clang-format on


### PR DESCRIPTION
- [x] Store LLVM IR in bytecode format for space saving
- [x] Failed Experiments are added in database
- [x] Always execute default O1->3 pipelines
- [x] Store failed experiments
- [x] When unable to allocate memory exit tuner    