### PR TITLE
Work in progress to support CUDA for Mneme autotune (python)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ class CMakeBuild(build_ext):
         self.has_nvidia = "On" if has_nvidia_gpu() else "Off"
         self.has_amd = "On" if has_amd_gpu() else "Off"
         self.llvm_dir = os.getenv("LLVM_INSTALL_DIR", None)
+        if self.has_amd == "On" and not self.llvm_dir:
+            self.llvm_dir = os.getenv("ROCM_PATH", None)
         if self.has_amd == "On":
             self.cxx = f"{self.llvm_dir}/bin/amdclang++"
             self.cc = f"{self.llvm_dir}/bin/amdclang"
@@ -60,6 +62,16 @@ class CMakeBuild(build_ext):
             raise RuntimeError(
                 "Error: LLVM_INSTALL_DIR is not set. Please export it before running setup.py."
             )
+
+        # TODO: Here we assume that NVIDIA based system use Conda LLVM
+        #       and that ROCm-based system use system LLVM (from ROCm).
+        # FIXME: Might be better to manage that with environnement variables
+        self.shared_llvm = "ON" if has_nvidia_gpu() else "OFF"
+
+        # TODO: find that code programtically or ask users to set 
+        #       an environnement variable CUDA_ARCH
+        # FIXME: we could also use CUDA_ARCHITECTURES=native in the CMake
+        self.cuda_arch = "70" if has_nvidia_gpu() else None
 
     def run(self):
         if not os.path.exists("third_party"):
@@ -118,7 +130,8 @@ class CMakeBuild(build_ext):
             "-DENABLE_TESTS=Off",
             f"-DCMAKE_C_COMPILER={self.cc}",
             f"-DCMAKE_CXX_COMPILER={self.cxx}",
-            "..",
+            f"-DPROTEUS_LINK_SHARED_LLVM={self.shared_llvm}",
+            ".."
         ]
 
         run_command(
@@ -174,16 +187,31 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_CXX_COMPILER={self.cxx}",
             f"-DLLVM_INSTALL_DIR={self.llvm_dir}",
             f"-DMNEME_ENABLE_HIP={self.has_amd}",
+            f"-DMNEME_ENABLE_CUDA={self.has_nvidia}",
             "-DMNEME_ENABLE_TESTS=On",
             "-DMNEME_ENABLE_AUTOTUNE=On",
             f"-Dproteus_DIR={self.install_dir}",
             f"-Dspdlog_DIR={self.install_dir}",
+            f"-DMNEME_LINK_SHARED_LLVM={self.shared_llvm}"
         ]
 
-        run_command(["cmake", ".."] + cmake_options, cwd=build_dir)
-        run_command(["make", "-j4"], cwd=build_dir)
-        run_command(["make", "-j4", "install"], cwd=build_dir)
+        if self.cuda_arch:
+            cmake_options.append(f"-DCMAKE_CUDA_ARCHITECTURES={self.cuda_arch}")
 
+        if self.has_nvidia == "On":
+            cmake_options.append(f"-DCMAKE_CUDA_COMPILER={self.cxx}")
+            lib_dir = os.path.join(self.llvm_dir, "lib")
+            # This is needed when using llvm installed by conda, sometimes llvm cannot find zstd
+            cmake_options.append(f"-DCMAKE_PREFIX_PATH={lib_dir}")
+            
+
+        cmake_options.append("..")
+        run_command(
+            ["cmake"] + cmake_options,
+            cwd=build_dir,
+        )
+        run_command(["make", "-j4"], cwd=build_dir)
+        run_command(["make", "install"], cwd=build_dir)
         built_module = glob.glob(
             os.path.join(build_dir, "src", "python", "libmneme*.so")
         )

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -6,6 +6,8 @@ file(GLOB LLVM_SRC "llvm/*.cpp")
 file(GLOB PROTEUS_SRC "proteus/*.cpp")
 file(GLOB MNEME_SRC "./*.cpp")
 
+# Needed because rpath to zstd was being messed up in a conda env
+SET(CMAKE_SKIP_BUILD_RPATH TRUE)
 
 add_library(mneme SHARED ${LLVM_SRC} ${PROTEUS_SRC} ${MNEME_SRC} ${MnemeCoreSrcDir}/MnemePageManager.cpp ${MnemeCoreSrcDir}/MnemeDeviceCode.cpp)
 
@@ -17,9 +19,8 @@ target_include_directories(mneme SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS} ${CMAKE_SOU
 target_link_libraries(mneme PRIVATE proteusCore)
 
 if (MNEME_ENABLE_LOGGER)
-target_link_libraries(mneme PRIVATE spdlog::spdlog_header_only)
-target_compile_definitions(mneme PRIVATE MNEME_ENABLE_LOGGER)
+  target_link_libraries(mneme PRIVATE spdlog::spdlog_header_only)
+  target_compile_definitions(mneme PRIVATE MNEME_ENABLE_LOGGER)
 endif()
-
 
 target_link_libraries(mneme PRIVATE ${LLVM_AVAILABLE_LIBS})

--- a/src/python/device.cpp
+++ b/src/python/device.cpp
@@ -1,6 +1,12 @@
 #include "llvm/core.h"
 #include <cstring>
+
+#ifdef MNEME_ENABLE_CUDA
+#include <cuda_runtime_api.h>
+#elif defined(MNEME_ENABLE_HIP)
 #include <hip/hip_runtime_api.h>
+#endif
+
 #include <llvm/Support/CBindingWrapping.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <mneme/MnemePython.hpp>

--- a/src/python/proteus/jit.cpp
+++ b/src/python/proteus/jit.cpp
@@ -44,8 +44,14 @@ ProteusPY_codeGenObject(LLVMModuleRef Mod, const char *DeviceArch, bool use_rtc,
   llvm::SmallPtrSet<void *, 8> GlobalLinkedBinaries;
   auto *M = llvm::unwrap(Mod);
   auto start = std::chrono::high_resolution_clock::now();
+  // FIXME: Proteus should have a uniform API for codegenObject
+#ifdef MNEME_ENABLE_CUDA
+  auto DeviceObject = proteus::codegenObject(
+      *M, DeviceArch, GlobalLinkedBinaries, use_rtc);
+#elif defined(MNEME_ENABLE_HIP)
   auto DeviceObject = proteus::codegenObject(
       *M, DeviceArch, GlobalLinkedBinaries, use_rtc, CodegenOptLevel);
+#endif
   auto end = std::chrono::high_resolution_clock::now();
 
   // Calculate duration and convert to seconds as float


### PR DESCRIPTION
At the moment `-DMNEME_ENABLE_AUTOTUNE=On` fails on CUDA systems. The Python side is not building correctly.

In addition, when using LLVM installed via Conda some unrelated issues arise, such as libzstd not found. This PR fixes that.

Fix #37 