### PR TITLE
Search space

### DIFF
--- a/python/mneme/tuning/search_space.py
+++ b/python/mneme/tuning/search_space.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+from .parameters import BaseParam
+
+
+class SearchSpace(ABC):
+    """
+    Declarative representation of a search space.
+
+    A SearchSpace describes:
+      • The **primary tunable dimensions** (dimensions())
+      • Any **derived parameters** computed from these (derived())
+      • Any **constraints** on valid configurations (constraints())
+    """
+
+    @abstractmethod
+    def dimensions(self) -> Dict[str, BaseParam]:
+        """
+        Return the top-level parameters of this search space.
+        Keys are parameter names, values are BaseParam instances.
+        """
+        pass
+
+    def derived(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Compute derived parameters from the given primary parameters.
+
+        Example:
+          - compute launch_bounds if block_dim/max_threads implies it
+          - compute grid_dim automatically from problem size
+        """
+        return {}
+
+    def constraints(self, params: Dict[str, Any]) -> bool:
+        """
+        Validate that this parameter assignment is legal.
+
+        Returns:
+            True if the assignment is valid, False otherwise.
+        """
+        return True
+

--- a/python/tests/tuning/test_search_space.py
+++ b/python/tests/tuning/test_search_space.py
@@ -1,0 +1,37 @@
+import pytest
+from mneme.tuning.parameters import IntRangeParam, BoolParam
+from mneme.tuning.search_space import SearchSpace
+
+
+class MySpace(SearchSpace):
+    def dimensions(self):
+        return {
+            "size": IntRangeParam("size", 1, 8, step=1),
+            "flag": BoolParam("flag"),
+        }
+
+    def derived(self, params):
+        return {"double": params["size"] * 2}
+
+    def constraints(self, params):
+        return params["size"] != 4
+
+
+def test_dimensions_return_params():
+    space = MySpace()
+    dims = space.dimensions()
+    assert "size" in dims and "flag" in dims
+    assert isinstance(dims["size"], IntRangeParam)
+
+
+def test_derived_parameters():
+    space = MySpace()
+    d = space.derived({"size": 3, "flag": True})
+    assert d["double"] == 6
+
+
+def test_constraints_filter():
+    space = MySpace()
+    assert space.constraints({"size": 3, "flag": True})
+    assert not space.constraints({"size": 4, "flag": False})
+


### PR DESCRIPTION
# PR2: Add SearchSpace Abstraction

## Summary

This PR introduces the `SearchSpace` class, which is a declarative container
for Mneme’s tunable parameters. A SearchSpace defines:

- `dimensions()` → the primary parameter objects
- `derived(params)` → computed values dependent on primary parameters
- `constraints(params)` → validation rules for the space

This PR does not include sampling, Optuna integration, or hierarchical
search. Those will be introduced in PR3–PR7.

## Motivation

Mneme tuning requires:
- a structured way to enumerate the tunable dimensions,
- a place for derived logic (e.g., launch bounds, block size interactions),
- a way to validate configurations before execution.

`SearchSpace` provides the foundation for these capabilities.

## Added

- `mneme/tuning/search_space.py`
- Example subclass for testing
- Initial tests validating dimensions/derived/constraints
