### PR TITLE
set alternate IR in replay executor

### DIFF
--- a/python/mneme/async_executor.py
+++ b/python/mneme/async_executor.py
@@ -87,6 +87,7 @@ class TuneWorkerHandle:
         device_id: int,
         iterations: int,
         results_db_dir: str,
+        new_ir_candidate: str = "",
     ):
         """
         Construct a worker handle and start the worker process + monitor thread.
@@ -108,6 +109,8 @@ class TuneWorkerHandle:
             Number of kernel iterations used by the worker for the tracked execution.
         results_db_dir : str
             Directory where the worker writes logs and optional artifacts.
+        new_ir_candidate : str
+            Path to the new LLVM IR file to be used for replay. If empty, uses the recorded IR.
 
         Notes
         -----
@@ -129,6 +132,7 @@ class TuneWorkerHandle:
         self.device_id = device_id
         self.iterations = iterations
         self.results_db_dir = results_db_dir
+        self.new_ir_candidate = new_ir_candidate
 
         self._state = None  # ProcessEvent
         self._process = None  # Process
@@ -172,6 +176,7 @@ class TuneWorkerHandle:
                 self.device_id,
                 self.iterations,
                 self.results_db_dir,
+                self.new_ir_candidate,
                 self._state,
             ),
             daemon=False,
@@ -364,6 +369,7 @@ class AsyncReplayExecutor:
         iterations: int,
         results_db_dir: str,
         num_workers: int,
+        new_ir_candidate: str = "",
     ):
         """
         Construct an asynchronous executor with a fixed-size worker pool.
@@ -380,6 +386,8 @@ class AsyncReplayExecutor:
             Directory where workers write logs and optional output artifacts.
         num_workers : int
             Number of worker processes to launch.
+        new_ir_candidate : str
+            Path to the new LLVM IR file to be used for replay. If empty, uses the recorded IR.
         """
         self.global_q = ThreadQueue()
         self._futures: Dict[int, EvalFuture] = {}
@@ -395,6 +403,7 @@ class AsyncReplayExecutor:
                 i,
                 iterations,
                 results_db_dir,
+                new_ir_candidate,
             )
             for i in range(num_workers)
         ]
@@ -469,3 +478,51 @@ class AsyncReplayExecutor:
         future = self.submit(config)
 
         return future.result()
+
+
+class AlternateIRReplayExecutor(AsyncReplayExecutor):
+    """
+    This executor subclass allows testing source-level transformations by replaying
+    kernels with an alternate LLVM IR module (provided as a file path) while still
+    using the recorded state from a different execution.
+
+    Right now just passes new_ir_candidate to superclass. Created as its own
+    class in case we want to add more here in the future.
+    """
+
+    def __init__(
+        self,
+        record_db: str,
+        record_id: str,
+        new_ir_candidate: str,
+        iterations: int,
+        results_db_dir: str,
+        num_workers: int,
+    ):
+        """
+        Construct the AlternateIRReplayExecutor.
+
+        Parameters
+        ----------
+        record_db : str
+            Path to the recorded execution database/file.
+        record_id : str
+            Identifier of the recorded kernel instance inside ``record_db``.
+        new_ir_candidate : str
+            Path to the new LLVM IR file to be used for replay.
+        iterations : int
+            Number of kernel iterations performed by each worker per tracked run.
+        results_db_dir : str
+            Directory where workers write logs and optional output artifacts.
+        num_workers : int
+            Number of worker processes to launch.
+        """
+        super().__init__(
+            record_db,
+            record_id,
+            iterations,
+            results_db_dir,
+            num_workers,
+            new_ir_candidate=new_ir_candidate,
+        )
+

--- a/python/mneme/replay_executor.py
+++ b/python/mneme/replay_executor.py
@@ -44,7 +44,7 @@ from mneme.device import (
     set_device,
 )
 from mneme.llvm.buffer import MemBufferRef
-from mneme.llvm.module import ModuleRef
+from mneme.llvm.module import ModuleRef, parse_assembly, parse_bitcode
 from mneme.logging import logger
 from mneme.mneme_types import ExperimentConfiguration, ExperimentResult
 from mneme.page_manager import PageManagerRef
@@ -713,6 +713,7 @@ class TuneWorker(BaseExecutor):
         device_id: int,
         iterations: int,
         results_db_dir: str,
+        new_ir_candidate: str,
         state: Event,
     ):
         """
@@ -758,6 +759,8 @@ class TuneWorker(BaseExecutor):
             on the executor pipeline).
         results_db_dir : str
             Directory where per-worker logs and output artifacts are written.
+        new_ir_candidate : str
+            Path to the new LLVM IR file to be used for replay. If empty, uses the recorded IR.
         state : multiprocessing.Event
             Event used to signal to the parent process that initialization is complete
             and the worker is ready to accept requests.
@@ -787,7 +790,19 @@ class TuneWorker(BaseExecutor):
         )
         # Open GPU memory, setup prologue epilogue and create a single
         # LLVM IR file to start working on optimizations
-        root_ir = worker.link_ir()
+        if new_ir_candidate:
+            with open(new_ir_candidate, "rb") as f:
+                content = f.read()
+
+            if new_ir_candidate.endswith(".ll"):
+                # parse_assembly expects a string
+                root_ir = parse_assembly(content.decode("utf-8"))
+            else:
+                # parse_bitcode expects bytes
+                root_ir = parse_bitcode(content)
+            logger.debug(f"Worker {device_id} loaded alternate IR from {new_ir_candidate}")
+        else:
+            root_ir = worker.link_ir()
 
         with worker as Memory:
             state.set()


### PR DESCRIPTION
Draft for now since I'm not sure if this is the best/correct way to do this.

Pass an alternate LLVM IR to async replay executor. I tested with some simple modified IR and it seems to work, but I haven't tried anything too crazy.

You could also just modify the .bc file in the mneme db. This might be cleaner than passing it to the interface. Let me know if one is preferred.