### PR TITLE
fix overflow bug

### DIFF
--- a/src/MnemeDeviceCode.cpp
+++ b/src/MnemeDeviceCode.cpp
@@ -13,19 +13,33 @@ using DeviceVendorTraits = DeviceTraits<DeviceVendors::HIP>;
 using DeviceVendorTraits = DeviceTraits<DeviceVendors::CUDA>;
 #endif
 
+constexpr int NUM_THREADS_PER_BLOCK = 256;
+
 __global__ void compareDevBlobs(const char *Blob1, const char *Blob2,
                                 unsigned long long *GSame, uint64_t MemSize) {
-  size_t ID = threadIdx.x + blockDim.x * blockIdx.x;
-  size_t GridSize = blockDim.x * gridDim.x;
-  unsigned long long NumEqual = 0;
+  uint64_t tid = (uint64_t)threadIdx.x;
+  uint64_t ID  = tid + (uint64_t)blockDim.x * (uint64_t)blockIdx.x;
+  uint64_t GridSize = (uint64_t)blockDim.x * (uint64_t)gridDim.x;
 
-  if (ID >= MemSize)
-    return;
-
-  for (int id = ID; id < MemSize; id += GridSize) {
-    NumEqual += (uint64_t)(Blob1[id] == Blob2[id]);
+  unsigned long long local = 0;
+  for (uint64_t i = ID; i < MemSize; i += GridSize) {
+    local += (Blob1[i] == Blob2[i]);
   }
-  atomicAdd(GSame, NumEqual);
+
+  __shared__ unsigned long long shmem[NUM_THREADS_PER_BLOCK];
+  shmem[threadIdx.x] = local;
+  __syncthreads();
+
+  for (int offset = blockDim.x / 2; offset > 0; offset >>= 1) {
+    if (threadIdx.x < offset) {
+      shmem[threadIdx.x] += shmem[threadIdx.x + offset];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    atomicAdd(GSame, shmem[0]);
+  }
 }
 
 bool DeviceVendorTraits::compareDeviceBlobs(const char *Blob1,
@@ -44,9 +58,9 @@ bool DeviceVendorTraits::compareDeviceBlobs(const char *Blob1,
   if (EC)
     LOG_FATAL("Error in comparing blobs " + EC.value());
 
-  constexpr int NumThreads = 256;
-  size_t NumBlocks = (NumBytes + NumThreads - 1) / NumThreads;
-  compareDevBlobs<<<NumBlocks, NumThreads>>>(Blob1, Blob2, NumEqualBytes,
+  uint64_t NumBlocks = min( (NumBytes + NUM_THREADS_PER_BLOCK - 1)/NUM_THREADS_PER_BLOCK,
+                  (uint64_t)8192 );   // DN -- you could also set this to something like SMs*20 to be more device dependent
+  compareDevBlobs<<<NumBlocks, NUM_THREADS_PER_BLOCK>>>(Blob1, Blob2, NumEqualBytes,
                                              NumBytes);
 
   EC = DeviceVendorTraits::DeviceErrorCheck(


### PR DESCRIPTION
Fixes an overflow bug in comparing the blobs. There was an overflow in setting the kernel launch number of blocks and the for loop index within the kernel. I think the threadIdx, blockIdx, and blockDim arithmetic might have also been overflowing but I'm not sure.
I fixed it by upcasting everything to uint64_t.

I've verified this for `./vecAdd 65536` with rocm 6.4.3. Without this commit I get `verified=False`. With this change I get `verified=True`.

Note: I also changed the kernel to do only one atomic per block instead of thread, since this was very slow for large blobs. I also limited the number of blocks to 8192 to make it faster (I thought HIP would take care of this, but this is a bit faster for me).

You could probably make this even faster with something like below. You only issue atomics if there's a mismatch and every other thread can early exit.
This would involve changing the launcher, so I didn't make the change, but let me know if you think I should change it.

```cuda
__global__ void compareDevBlobs(const unsigned char* Blob1,
                                 const unsigned char* Blob2,
                                 unsigned int* mismatch,
                                 uint64_t MemSize) {
  uint64_t ID  = (uint64_t)threadIdx.x + (uint64_t)blockDim.x * (uint64_t)blockIdx.x;
  uint64_t GridSize = (uint64_t)blockDim.x * (uint64_t)gridDim.x;

  for (uint64_t i = ID; i < MemSize; i += GridSize) {
    if (*mismatch) return;

    if (Blob1[i] != Blob2[i]) {
      atomicExch(mismatch, 1u);
      return;
    }
  }
  ```