### PR TITLE
Rename proteus headers to .h extension

### DIFF
--- a/cmake/MnemeFunctions.cmake
+++ b/cmake/MnemeFunctions.cmake
@@ -1,5 +1,7 @@
 function(add_mneme target)
-    add_proteus(${target} FORCE_JIT_ANNOTATE_ALL)
+    # Link proteus as a shared library for preloading.
+    # TODO: Change to static linking and use linker wrapper flags for interposing.
+    add_proteus(${target} FORCE_JIT_ANNOTATE_ALL LINK_SHARED)
     string(TOLOWER "${CMAKE_CXX_COMPILER}" _cxx)
     set(_looks_like_clang FALSE)
     if(_cxx MATCHES "clang|amdclang|hipcc")

--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -21,8 +21,8 @@ on internal test systems.
 | ROCm version | Python 3.9 | Python 3.10 | Python 3.11 | Python 3.12 |
 |-------------|------------|-------------|-------------|-------------|
 | **6.3**     | ✅         | ✅          | ✅          | ✅          |
-| **6.4**     | ✅         | ✅          | ✅          | ✅          | 
-| **7.0**     | ⏳         | ⏳          | ⏳          | ⏳          | 
+| **6.4**     | ✅         | ✅          | ✅          | ✅          |
+| **7.0**     | ⏳         | ⏳          | ⏳          | ⏳          |
 
 #### Notes
 
@@ -58,7 +58,7 @@ use the corresponding Proteus commit to avoid incompatibilities.
 #### Tested Proteus commit
 
 - Repository: https://github.com/Olympus-HPC/Proteus
-- Commit: `1d21c00008061704459a9b20300556e962c89043`  
+- Commit: `53304d087f0dae2618439565c87a6d3fe82eb36d`
 - Tested with: Mneme `develop`
 
 !!! note
@@ -197,4 +197,3 @@ Python bindings are correctly installed.
 Once Mneme is installed and the test suite completes successfully,
 proceed to **Getting Started** for a guided, end-to-end example of
 building, recording, and replaying a GPU kernel with Mneme.
-

--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -58,7 +58,7 @@ use the corresponding Proteus commit to avoid incompatibilities.
 #### Tested Proteus commit
 
 - Repository: https://github.com/Olympus-HPC/Proteus
-- Commit: `53304d087f0dae2618439565c87a6d3fe82eb36d`
+- Commit: `v2026.01.0`
 - Tested with: Mneme `develop`
 
 !!! note

--- a/include/mneme/MnemeJITProteus.hpp
+++ b/include/mneme/MnemeJITProteus.hpp
@@ -1,9 +1,9 @@
-#include <proteus/CoreLLVM.hpp>
-#include <proteus/CoreLLVMDevice.hpp>
+#include <proteus/CoreLLVM.h>
+#include <proteus/CoreLLVMDevice.h>
 
 #include <llvm/Support/InitLLVM.h>
 #ifdef MNEME_ENABLE_HIP
-#include <proteus/CoreLLVMHIP.hpp>
+#include <proteus/CoreLLVMHIP.h>
 #elif defined(MNEME_ENABLE_CUDA)
 #else
 #error "Please define MNEME_ENABLE_HIP or MNEME_ENABLE_CUDA"

--- a/include/mneme/MnemeRecord.hpp
+++ b/include/mneme/MnemeRecord.hpp
@@ -22,7 +22,7 @@
 #include <mutex>
 
 #include <proteus/CompilerInterfaceDevice.h>
-#include <proteus/JitEngineDevice.hpp>
+#include <proteus/JitEngineDevice.h>
 
 #include "mneme/DeviceTraits.hpp"
 #include "mneme/MnemeKernelInfo.hpp"

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -16,8 +16,8 @@
 #include <sys/types.h>
 
 #include "proteus/CompilerInterfaceDevice.h"
-#include "proteus/Hashing.hpp"
-#include <proteus/JitEngineDevice.hpp>
+#include "proteus/Hashing.h"
+#include <proteus/JitEngineDevice.h>
 
 #include "mneme/DeviceTraits.hpp"
 #include "mneme/MnemeKernelInfo.hpp"

--- a/scripts/gitlab/ci-build-test.sh
+++ b/scripts/gitlab/ci-build-test.sh
@@ -16,8 +16,8 @@ build_proteus() {
   if [[ ! -d proteus ]]; then
   	git clone --depth 1 git@github.com:Olympus-HPC/proteus.git
     pushd proteus
-    git fetch --depth 1 origin 53304d087f0dae2618439565c87a6d3fe82eb36d
-    git checkout 53304d087f0dae2618439565c87a6d3fe82eb36d
+    git fetch --depth 1 origin v2026.01.0
+    git checkout v2026.01.0
     popd
   fi
   pushd proteus

--- a/scripts/gitlab/ci-build-test.sh
+++ b/scripts/gitlab/ci-build-test.sh
@@ -15,12 +15,12 @@ build_proteus() {
   echo "Building PROTEUS"
   if [[ ! -d proteus ]]; then
   	git clone --depth 1 git@github.com:Olympus-HPC/proteus.git
-    pushd proteus 
-    git fetch --depth 1 origin 1d21c00008061704459a9b20300556e962c89043 
-    git checkout 1d21c00008061704459a9b20300556e962c89043 
+    pushd proteus
+    git fetch --depth 1 origin 53304d087f0dae2618439565c87a6d3fe82eb36d
+    git checkout 53304d087f0dae2618439565c87a6d3fe82eb36d
     popd
   fi
-  pushd proteus 
+  pushd proteus
   PROTEUS_ENABLE_HIP=$1
   PROTEUS_ENABLE_CUDA=$2
   PROTEUS_INSTALL_DIR=$3
@@ -68,7 +68,7 @@ build_spdlog() {
   -DCMAKE_C_COMPILER=${LLVM_INSTALL_DIR}/bin/clang \
   -DCMAKE_CXX_COMPILER=${LLVM_INSTALL_DIR}/bin/clang++ \
   -DCMAKE_INSTALL_PREFIX=${SPDLOG_INSTALL_DIR} \
-  .. 
+  ..
 
   make -j 10
   make install -j 10
@@ -94,7 +94,7 @@ conda create -y -n mneme -c conda-forge \
 else
 source ./${MINICONDA_DIR}/bin/activate
 fi
-conda activate mneme 
+conda activate mneme
 
 LLVM_INSTALL_DIR=$(llvm-config --prefix)
 export LLVM_INSTALL_DIR=$(llvm-config --prefix)
@@ -107,7 +107,7 @@ echo "After proteus Current directory is $(pwd)"
 build_spdlog $installDir
 mneme_src=$(pwd)
 set -x
-pushd $build_dir 
+pushd $build_dir
 echo "Current dir is $(pwd)"
 cmake \
 -DCMAKE_BUILD_TYPE=Debug \
@@ -137,7 +137,7 @@ echo "After proteus Current directory is $(pwd)"
 build_spdlog $installDir
 echo "After spdlog Current directory is $(pwd)"
 mneme_src=$(pwd)
-pushd $build_dir 
+pushd $build_dir
 cmake \
 -DCMAKE_BUILD_TYPE=Relwithdebinfo \
 -Dproteus_DIR=$installDir \

--- a/setup.py
+++ b/setup.py
@@ -182,12 +182,12 @@ MNEME_CONFIG_FILE = str(_NATIVE / "config.json")
                         "--depth",
                         "1",
                         "origin",
-                        "53304d087f0dae2618439565c87a6d3fe82eb36d",
+                        "v2026.01.0",
                     ],
                     cwd=str(Path(self.build_scratch) / "proteus"),
                 )
                 run_command(
-                    ["git", "checkout", "53304d087f0dae2618439565c87a6d3fe82eb36d"],
+                    ["git", "checkout", "v2026.01.0"],
                     cwd=str(Path(self.build_scratch) / "proteus"),
                 )
 

--- a/setup.py
+++ b/setup.py
@@ -182,12 +182,12 @@ MNEME_CONFIG_FILE = str(_NATIVE / "config.json")
                         "--depth",
                         "1",
                         "origin",
-                        "1d21c00008061704459a9b20300556e962c89043",
+                        "53304d087f0dae2618439565c87a6d3fe82eb36d",
                     ],
                     cwd=str(Path(self.build_scratch) / "proteus"),
                 )
                 run_command(
-                    ["git", "checkout", "1d21c00008061704459a9b20300556e962c89043"],
+                    ["git", "checkout", "53304d087f0dae2618439565c87a6d3fe82eb36d"],
                     cwd=str(Path(self.build_scratch) / "proteus"),
                 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,9 @@ endif()
 
 
 target_include_directories(record SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(record PRIVATE proteus)
+# Link the record preload shared library with proteus shared library to avoid
+# LLVM static initialization issues.
+target_link_libraries(record PRIVATE proteus_shared)
 
 if (MNEME_ENABLE_LOGGER)
         target_link_libraries(record PRIVATE spdlog::spdlog_header_only)

--- a/src/MnemeReplay.cpp
+++ b/src/MnemeReplay.cpp
@@ -6,12 +6,12 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/Support/CommandLine.h>
 
-#include <proteus/CoreLLVM.hpp>
-#include <proteus/CoreLLVMDevice.hpp>
+#include <proteus/CoreLLVM.h>
+#include <proteus/CoreLLVMDevice.h>
 
 #include <llvm/Support/InitLLVM.h>
 #ifdef MNEME_ENABLE_HIP
-#include <proteus/CoreLLVMHIP.hpp>
+#include <proteus/CoreLLVMHIP.h>
 #elif defined(MNEME_ENABLE_CUDA)
 #else
 #error "Please define MNEME_ENABLE_HIP or MNEME_ENABLE_CUDA"

--- a/src/python/llvm/initfini.cpp
+++ b/src/python/llvm/initfini.cpp
@@ -1,7 +1,7 @@
 #include "core.h"
 #include "llvm/Config/llvm-config.h"
 #include <iostream>
-#include <proteus/CoreLLVM.hpp>
+#include <proteus/CoreLLVM.h>
 
 namespace {
 class LLVMInstance {

--- a/src/python/proteus/jit.cpp
+++ b/src/python/proteus/jit.cpp
@@ -10,9 +10,9 @@
 #include <mneme/MnemeLogger.hpp>
 #include <proteus/CompilerInterfaceRuntimeConstantInfo.h>
 #include <proteus/CompilerInterfaceTypes.h>
-#include <proteus/CoreLLVM.hpp>
-#include <proteus/CoreLLVMDevice.hpp>
-#include <proteus/Hashing.hpp>
+#include <proteus/CoreLLVM.h>
+#include <proteus/CoreLLVMDevice.h>
+#include <proteus/Hashing.h>
 
 using namespace proteus;
 


### PR DESCRIPTION
Align with Olympus-HPC/proteus#376

Fix issue with LLVM static linking

> [!NOTE]
> We need to change the commit version in `setup.py` and elsewhere once https://github.com/Olympus-HPC/proteus/pull/383 lands