### PR TITLE
CI: replace broken rocm/7.1.0 with 7.1.1 on tioga/tuolumne

### DIFF
--- a/.gitlab/jobs/tioga-python-cov.yml
+++ b/.gitlab/jobs/tioga-python-cov.yml
@@ -53,7 +53,7 @@ variables:
 .build-variants:
   parallel:
     matrix:
-      - MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.0"]
+      - MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.1"]
         MNEME_CI_PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12"]
 
 tioga-test-python-cov:

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -55,7 +55,7 @@ variables:
   parallel:
     matrix:
       - MNEME_CI_ENABLE_LOGGER: ["on", "off"]
-        MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.0"]
+        MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.1"]
 
 build-and-test-tioga:
   extends: [.base-job, .build-variants]

--- a/.gitlab/jobs/tuolumne-python-cov.yml
+++ b/.gitlab/jobs/tuolumne-python-cov.yml
@@ -53,7 +53,7 @@ variables:
 .build-variants:
   parallel:
     matrix:
-      - MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.0"]
+      - MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.1"]
         MNEME_CI_PYTHON_VERSION: ["3.9", "3.10", "3.11", "3.12"]
 
 tuolumne-test-python-cov:

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -55,7 +55,7 @@ variables:
   parallel:
     matrix:
       - MNEME_CI_ENABLE_LOGGER: ["on", "off"]
-        MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.0"]
+        MNEME_CI_ROCM_VERSION: ["6.3.1", "6.4.2", "7.1.1"]
 
 build-and-test-tuolumne:
   extends: [.base-job, .build-variants]

--- a/docs/concepts/llvm-boundary.md
+++ b/docs/concepts/llvm-boundary.md
@@ -128,7 +128,7 @@ See [Artifacts](artifacts.md) for where recorded .bc files are stored and how th
 LLVM IR is a powerful boundary, but it comes with practical constraints:
 
 - Toolchain coupling: Recorded IR must remain compatible with the LLVM toolchain used
-for replay. Mneme is tested with ROCm-provided LLVM versions (e.g., LLVM 18/19).
+for replay. Mneme is tested with ROCm-provided LLVM versions (e.g., LLVM 18/19/20).
 - Not full-program replay: Mneme records kernel-level IR, not host-side control flow.
 - Backend differences matter: Code generation decisions (and performance) may vary across
 GPU targets, LLVM versions, and codegen options.

--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -97,8 +97,8 @@ The following tools and libraries must be available:
 - LLVM libraries
 
 These tools are provided by the **LLVM distribution bundled with ROCm**.
-Mneme is currently tested with **LLVM 18 and LLVM 19** as shipped by
-supported ROCm releases.
+Mneme is currently tested with **LLVM 18, 19, and 20** as shipped by
+supported ROCm releases (6.3, 6.4, and 7.1 respectively).
 
 !!! note
     Mneme expects the ROCm-provided LLVM toolchain to be used.


### PR DESCRIPTION
- `rocm/7.1.0` points to `/opt/rocm-7.1.0`, which is not installed on tioga or tuolumne, so `build-and-test-{tioga,tuolumne}` were failing at CMake configure time.
- Swap `7.1.0` → `7.1.1`.

Fixes #141