### PR TITLE
Isolate record tests so ctest -jN is race-free

### DIFF
--- a/tests/record/CMakeLists.txt
+++ b/tests/record/CMakeLists.txt
@@ -76,13 +76,23 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/read-record.py ${CMAKE_CURRENT_BINARY
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
+import os
+import tempfile
+import atexit
+import shutil
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
+config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
-config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
+# Create a unique temp exec_root per ctest invocation to avoid races on
+# lit_test_times.txt and on test artifacts under ctest -jN.
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
 MNEME_PRELOAD_LIB='${CMAKE_BINARY_DIR}/src/librecord.so'
 PAGE_SIZE = lit_config.params['PG']
 RR = lit_config.params['RR']
@@ -93,6 +103,7 @@ config.substitutions.append(('%PG', PAGE_SIZE))
 config.substitutions.append(('%RR', RR))
 config.substitutions.append(('%ext', EXT))
 config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
 "
 )
 

--- a/tests/record/indirect_launcher_tpl_multi_arg.cpp
+++ b/tests/record/indirect_launcher_tpl_multi_arg.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./indirect_launcher_tpl_multi_arg%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/indirect_launcher_tpl_multi_arg%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>

--- a/tests/record/kernel.cpp
+++ b/tests/record/kernel.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./kernel%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/kernel%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>

--- a/tests/record/multi_file1.cpp
+++ b/tests/record/multi_file1.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=off MNEME_PAGE_SIZE=%PG ./test_multi_file%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=off MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_multi_file%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>

--- a/tests/record/multi_file1_kernel_launcher.cpp
+++ b/tests/record/multi_file1_kernel_launcher.cpp
@@ -1,9 +1,9 @@
 // clang-format off
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=off MNEME_PAGE_SIZE=%PG ./test_multi_file_launcher%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=off MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_multi_file_launcher%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on#include <climits>
 //
 #include <cstdio>

--- a/tests/record/multi_kernel_regex.cpp
+++ b/tests/record/multi_kernel_regex.cpp
@@ -1,11 +1,11 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./multi_kernel_regex%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR-NOREGEX
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: MNEME_RR_KERNELS="_two" LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./multi_kernel_regex%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR-WITH-REGEX
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/multi_kernel_regex%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR-NOREGEX
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: MNEME_RR_KERNELS="_two" LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/multi_kernel_regex%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR-WITH-REGEX
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>

--- a/tests/record/read-record.py
+++ b/tests/record/read-record.py
@@ -1,5 +1,6 @@
 import glob
 import json
+import os
 import struct
 import sys
 from pathlib import Path
@@ -79,7 +80,8 @@ def _parse_prologue_metadata(filename):
         )
     return results
 
-for fn in glob.glob("./*.json"):
+data_dir = sys.argv[1] if len(sys.argv) > 1 else "."
+for fn in sorted(glob.glob(os.path.join(data_dir, "*.json"))):
     with open(fn, "r") as fd:
         rr_data = json.load(fd)
     d_name = rr_data["DemangledName"]

--- a/tests/record/test_annotation.cpp
+++ b/tests/record/test_annotation.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_annotation%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_annotation%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <iostream>

--- a/tests/record/test_block_grid_1d.cpp
+++ b/tests/record/test_block_grid_1d.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_1d%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_block_grid_1d%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>

--- a/tests/record/test_block_grid_2d.cpp
+++ b/tests/record/test_block_grid_2d.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_2d%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_block_grid_2d%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>

--- a/tests/record/test_block_grid_3d.cpp
+++ b/tests/record/test_block_grid_3d.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
-// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG ./test_block_grid_3d%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: %RR | %FILECHECK %s --check-prefix=CHECK-RR
-// RUN: rm -rf *.json Recorded*.bc DeviceState*.mneme
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: MNEME_MAX_RECORDINGS=100 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_block_grid_3d%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
 #include <climits>


### PR DESCRIPTION
All `tests/record/*` lit tests share `tests/record/` as their working directory, and their RUN blocks bracket each test with `rm -rf *.json Recorded*.bc DeviceState*.mneme`. Under `ctest -jN` this lets one test wipe another test's artifacts mid-run, producing intermittent FileCheck failures. Fix by following Proteus's pattern (`proteus/tests/gpu/CMakeLists.txt` + RUN lines):

- `tests/record/CMakeLists.txt`: have `lit.cfg.py` create a per-invocation `tempfile.mkdtemp` `test_exec_root` (with `atexit` cleanup) so concurrent ctest runs do not race on `lit_test_times.txt`. Add a `%build` substitution pointing at `${CMAKE_CURRENT_BINARY_DIR}` so RUN lines can invoke the test binary by absolute path.
- Every `tests/record/*.cpp` RUN block: replace cwd-globbing cleanups and `./binary%ext` invocations with a per-test scratch dir `%t.$$.mneme` (lit's per-test basename plus the runtime shell PID) and `MNEME_DATA_DIR="%t.$$.mneme" %build/binary%ext`. Each test owns its own dir; `rm -rf` only touches that dir.
- `tests/record/read-record.py`: accept the data directory as `sys.argv[1]` (defaulting to `.`) and `sorted()` the glob for deterministic output.

Verified on tuolumne with rocm/6.4.0: `ctest -j16` is 22/22 green.