### PR TITLE
Auto-create --record-db-dir if it does not exist

### DIFF
--- a/python/mneme/commands.py
+++ b/python/mneme/commands.py
@@ -260,11 +260,9 @@ class Record:
         logger.debug(f"MNEME_MAX_RECORDINGS={args.per_kernel_max_recordings}")
         record_env["MNEME_MAX_RECORDINGS"] = str(args.per_kernel_max_recordings)
         record_db_dir = Path(args.record_db_dir).resolve()
-        if not record_db_dir.exists():
-            raise FileNotFoundError(f"Directory '{args.record_db_dir}' does not exist")
-
-        if not record_db_dir.is_dir():
+        if record_db_dir.exists() and not record_db_dir.is_dir():
             raise NotADirectoryError(f"Path '{args.record_db_dir}' is not a directory")
+        record_db_dir.mkdir(parents=True, exist_ok=True)
 
         logger.debug(f"MNEME_DATA_DIR={str(record_db_dir)}")
         record_env["MNEME_DATA_DIR"] = str(record_db_dir)

--- a/python/tests/test_cli_record.py
+++ b/python/tests/test_cli_record.py
@@ -95,18 +95,24 @@ def test_record_requires_dash_dash(record_parser, monkeypatch):
         Record.run(args, verbosity=None)
 
 
-def test_record_fails_if_dir_missing(record_parser, tmp_path, monkeypatch):
-    """record-db-dir must exist."""
-    missing = tmp_path / "nope"
+def test_record_creates_dir_if_missing(record_parser, tmp_path, monkeypatch):
+    """A missing record-db-dir is created automatically."""
+    missing = tmp_path / "nested" / "nope"
 
     monkeypatch.setattr(utils_mod, "get_mneme_record_library_name", lambda: "/tmp/x.so")
+
+    class FakeCode:
+        returncode = 0
+
+    monkeypatch.setattr(record_mod.subprocess, "run", lambda cmd, env=None, **kw: FakeCode)
 
     args = record_parser.parse_args(
         ["--record-db-dir", str(missing), "--", "/usr/bin/true"]
     )
 
-    with pytest.raises(FileNotFoundError):
-        Record.run(args, verbosity=None)
+    Record.run(args, verbosity=None)
+
+    assert missing.is_dir()
 
 
 def test_record_fails_if_not_a_directory(record_parser, tmp_path, monkeypatch):


### PR DESCRIPTION


- `mneme record -rdb <dir>` previously failed with `FileNotFoundError` when `<dir>` did not exist. Most CLIs create their output directory on demand, so this was a surprising failure mode.
- The Record command now creates the directory (and any missing parents) instead of raising. The existing not-a-directory guard is preserved so passing a regular file still raises `NotADirectoryError`.
- Updated the corresponding test (`test_record_fails_if_dir_missing` → `test_record_creates_dir_if_missing`) to assert the new behavior.
