### PR TITLE
Fix record max recordings CLI wiring

### DIFF
--- a/python/mneme/commands.py
+++ b/python/mneme/commands.py
@@ -257,6 +257,8 @@ class Record:
         record_env["LD_PRELOAD"] = librecord_path
         logger.debug(f"MNEME_PAGE_SIZE={args.virtual_address_space_size}")
         record_env["MNEME_PAGE_SIZE"] = str(args.virtual_address_space_size)
+        logger.debug(f"MNEME_MAX_RECORDINGS={args.per_kernel_max_recordings}")
+        record_env["MNEME_MAX_RECORDINGS"] = str(args.per_kernel_max_recordings)
         record_db_dir = Path(args.record_db_dir).resolve()
         if not record_db_dir.exists():
             raise FileNotFoundError(f"Directory '{args.record_db_dir}' does not exist")

--- a/python/tests/test_cli_record.py
+++ b/python/tests/test_cli_record.py
@@ -78,6 +78,7 @@ def test_record_happy_path(tmp_path, record_parser, monkeypatch):
     env = captured["env"]
     assert env["LD_PRELOAD"] == fake_lib
     assert env["MNEME_PAGE_SIZE"] == "8"
+    assert env["MNEME_MAX_RECORDINGS"] == "3"
     assert env["MNEME_DATA_DIR"] == str(record_dir)
     assert env["MNEME_LOG_LEVEL"] == "DEBUG"
 


### PR DESCRIPTION
Wire the record CLI's per-kernel max recordings option through to the native recorder environment.

- Export MNEME_MAX_RECORDINGS from --per-kernel-max-recordings in mneme record
- Assert the generated recording environment includes the configured max-recordings value