### PR TITLE
Use non-exclusive Matrix CI allocation

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -54,7 +54,7 @@ variables:
 # Time in minutes.
 # Arguments for top level allocation
 # Note: can be set to "OFF" to prevent allocation sharing.
-  MATRIX_SHARED_ALLOC: "--exclusive --gpus=1 --nodes=1 --time=60 --partition=pdebug"
+  MATRIX_SHARED_ALLOC: "--gpus=1 --nodes=1 --time=60 --partition=pdebug"
 # Arguments for job level allocation
   MATRIX_JOB_ALLOC: "--gpus=1 --nodes=1"
 


### PR DESCRIPTION
Use a non-exclusive Matrix CI allocation to reduce pdebug queue pressure and match proteus.

- Remove `--exclusive` from `MATRIX_SHARED_ALLOC` for Matrix CI.
- Keep the existing 1-GPU, 1-node, 60-minute pdebug allocation request.