### PR TITLE
Store record-DB paths as basenames relative to the JSON file

### DIFF
--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -574,7 +574,7 @@ private:
 
     LOG_DEBUG("Stored Blob with StaticHash:{} to file {}", StaticHash,
               std::filesystem::canonical(Filename).string());
-    return std::filesystem::canonical(Filename).string();
+    return std::filesystem::path(Filename).filename().string();
   }
 
 public:
@@ -673,6 +673,7 @@ public:
         SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory, Filename,
                                           KernelArgSizes, Args, Stream,
                                           PrologueGlobals.get())
+            .filename()
             .string();
 
     std::function<void(
@@ -699,6 +700,7 @@ public:
                     SnapshotT::takeMnemeBytesSnapshot(
                         GlobalVars, DeviceMemory, Filename, KernelArgSizes,
                         Args, Stream)
+                        .filename()
                         .string();
                 break;
               case EpilogueSnapshotType::Diff:
@@ -706,6 +708,7 @@ public:
                     SnapshotT::takeMnemeDiffSnapshot(
                         GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
                         Stream)
+                        .filename()
                         .string();
                 break;
               }

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -391,7 +391,7 @@ public:
                                KernelArgSizes[I]);
     }
 
-    return std::filesystem::canonical(Filename);
+    return Filename.filename();
   }
 
   std::filesystem::path static takeMnemeDiffSnapshot(
@@ -452,7 +452,7 @@ public:
       writeCountAndWriteChangedRanges(OutBC, Blob);
     }
 
-    return std::filesystem::canonical(Filename);
+    return Filename.filename();
   }
 
   void static readMnemeSnapShot(
@@ -673,7 +673,6 @@ public:
         SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory, Filename,
                                           KernelArgSizes, Args, Stream,
                                           PrologueGlobals.get())
-            .filename()
             .string();
 
     std::function<void(
@@ -700,7 +699,6 @@ public:
                     SnapshotT::takeMnemeBytesSnapshot(
                         GlobalVars, DeviceMemory, Filename, KernelArgSizes,
                         Args, Stream)
-                        .filename()
                         .string();
                 break;
               case EpilogueSnapshotType::Diff:
@@ -708,7 +706,6 @@ public:
                     SnapshotT::takeMnemeDiffSnapshot(
                         GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
                         Stream)
-                        .filename()
                         .string();
                 break;
               }

--- a/python/mneme/recorded_execution.py
+++ b/python/mneme/recorded_execution.py
@@ -102,14 +102,20 @@ def find_non_jsonables(obj, where="$"):
 
 def _make_path_relative(p, base_dir):
     """
-    Return ``p`` as a basename if it is an absolute path whose parent equals
-    ``base_dir``. Otherwise return ``p`` unchanged. If ``base_dir`` is ``None``,
-    no relativization is performed.
+    Return ``p`` as a basename if it lives directly under ``base_dir``.
+
+    If ``p`` is already a basename, return it unchanged so this transform is
+    idempotent. Relative paths with directory components are ambiguous here
+    because JSON readers resolve them against ``base_dir``.
     """
     if base_dir is None or not p:
         return p
     pp = Path(p)
-    if pp.is_absolute() and pp.parent.resolve() == base_dir:
+    if not pp.is_absolute():
+        if pp.parent == Path("."):
+            return p
+        raise ValueError(f"Expected absolute path or basename, got relative path: {p}")
+    if pp.parent.resolve() == base_dir:
         return pp.name
     return p
 

--- a/python/mneme/recorded_execution.py
+++ b/python/mneme/recorded_execution.py
@@ -100,6 +100,20 @@ def find_non_jsonables(obj, where="$"):
         print("Non-JSON type:", where, "->", type(obj))
 
 
+def _make_path_relative(p, base_dir):
+    """
+    Return ``p`` as a basename if it is an absolute path whose parent equals
+    ``base_dir``. Otherwise return ``p`` unchanged. If ``base_dir`` is ``None``,
+    no relativization is performed.
+    """
+    if base_dir is None or not p:
+        return p
+    pp = Path(p)
+    if pp.is_absolute() and pp.parent.resolve() == base_dir:
+        return pp.name
+    return p
+
+
 class MemStateRef:
     """
     Handle to a recorded memory snapshot (prologue/epilogue).
@@ -397,9 +411,13 @@ class RecordedExecution:
         def __str__(self):
             return f"Grid:{self.grid_dim}, BlockDim: {self.block_dim}, Shared Memory {self.shared_mem}"
 
-        def to_dict(self):
+        def to_dict(self, base_dir: "Path | None" = None):
             """
             Convert this instance into a JSON-friendly dictionary.
+
+            If ``base_dir`` is provided, snapshot paths whose parent directory
+            equals ``base_dir`` are written as basenames (relative form).
+            Otherwise paths are written as-is.
 
             Returns
             -------
@@ -413,8 +431,8 @@ class RecordedExecution:
             res["GridDims"] = self.grid_dim.to_dict()
             res["Occurrences"] = self.occ
             res["SharedMem"] = self.shared_mem
-            res["Epilogue"] = self.epilogue.fn
-            res["Prologue"] = self.prologue.fn
+            res["Epilogue"] = _make_path_relative(self.epilogue.fn, base_dir)
+            res["Prologue"] = _make_path_relative(self.prologue.fn, base_dir)
 
             return res
 
@@ -499,34 +517,41 @@ class RecordedExecution:
 
         return self._link_mod
 
-    def to_dict(self):
+    def to_dict(self, base_dir: "Path | None" = None):
         res = {}
         res["ArgNames"] = self.arg_names
         res["BinaryBlobs"] = []
         res["DemangledName"] = self.demangled_name
         res["KernelName"] = self.kernel_name
-        res["Modules"] = self.llvm_files
+        res["Modules"] = [_make_path_relative(m, base_dir) for m in self.llvm_files]
         res["Specializations"] = self.specializations
         res["StaticHash"] = self.static_hash
         res["VASize"] = self.va_size
         res["VAddr"] = self.va_addr
         res["instances"] = {}
         for k, v in self.items():
-            res["instances"][k] = v.to_dict()
+            res["instances"][k] = v.to_dict(base_dir)
         return res
 
     def to_json(self, fn: str):
         """
         Serialize this record database to a JSON file.
 
+        Paths to artifacts that live in the same directory as the JSON file
+        are written as basenames so that the resulting database is relocatable
+        with plain ``cp`` / ``mv``. Paths outside that directory are kept as
+        absolute paths.
+
         Parameters
         ----------
         fn : str
             Output JSON path.
         """
-        find_non_jsonables(self.to_dict())
+        base_dir = Path(fn).resolve().parent
+        d = self.to_dict(base_dir=base_dir)
+        find_non_jsonables(d)
         with open(fn, "w") as fd:
-            json.dump(self.to_dict(), fd, indent=2)
+            json.dump(d, fd, indent=2)
 
     @classmethod
     def from_json(cls, fn: str):
@@ -557,6 +582,14 @@ class RecordedExecution:
         with open(fn, "r") as fd:
             record_db = json.load(fd)
 
+        # Paths in the JSON may be either absolute (legacy) or relative to the
+        # JSON file's parent directory. Resolve to absolute so all in-memory
+        # consumers see a stable, cwd-independent path.
+        base_dir = Path(fn).resolve().parent
+
+        def _resolve(p: str) -> str:
+            return p if Path(p).is_absolute() else str(base_dir / p)
+
         instances = {}
         for dhash, inst in record_db["instances"].items():
             block_dim = dim3(
@@ -575,11 +608,12 @@ class RecordedExecution:
                 grid_dim,
                 record_db["Specializations"],
                 inst["Occurrences"],
-                inst["Prologue"],
-                inst["Epilogue"],
+                _resolve(inst["Prologue"]),
+                _resolve(inst["Epilogue"]),
             )
 
-        for llvm_fn in record_db["Modules"]:
+        resolved_modules = [_resolve(m) for m in record_db["Modules"]]
+        for llvm_fn in resolved_modules:
             if not Path(llvm_fn).exists():
                 raise RuntimeError(f"File {llvm_fn} does not exist")
 
@@ -587,7 +621,7 @@ class RecordedExecution:
             record_db["StaticHash"],
             record_db["KernelName"],
             record_db["DemangledName"],
-            record_db["Modules"],
+            resolved_modules,
             record_db["ArgNames"],
             record_db["Specializations"],
             record_db["VAddr"],

--- a/python/tests/cli/test_copy.py
+++ b/python/tests/cli/test_copy.py
@@ -3,16 +3,30 @@ import pathlib
 import re
 
 from mneme.cli import main as mneme_main
+from mneme.recorded_execution import RecordedExecution
 
 
-def test_copy(recorded_execution, tmp_path):
+def test_copy(recorded_execution, tmp_path, monkeypatch):
     src = recorded_execution
     dst = tmp_path / "copy"
     dst.mkdir()
 
     result = mneme_main(["copy", str(src), str(dst)])
     assert result == 0
-    src_records = set(src.glob("*.json"))
-    dest_records = set(dst.glob("*.json"))
+    src_records = set(p.name for p in src.parent.glob("*.json"))
+    dest_records = set(p.name for p in dst.glob("*.json"))
     diff = src_records - dest_records
     assert not diff, f"The sets should be empty {diff}"
+
+    dest_json = next(dst.glob("*.json"))
+    written = json.loads(dest_json.read_text())
+    for m in written["Modules"]:
+        assert "/" not in m, f"Module path should be a basename: {m}"
+    for inst in written["instances"].values():
+        assert "/" not in inst["Prologue"], inst["Prologue"]
+        assert "/" not in inst["Epilogue"], inst["Epilogue"]
+
+    foreign_cwd = tmp_path / "elsewhere"
+    foreign_cwd.mkdir()
+    monkeypatch.chdir(foreign_cwd)
+    RecordedExecution.from_json(str(dest_json))

--- a/python/tests/cli/test_move.py
+++ b/python/tests/cli/test_move.py
@@ -3,9 +3,10 @@ import pathlib
 import re
 
 from mneme.cli import main as mneme_main
+from mneme.recorded_execution import RecordedExecution
 
 
-def test_move(recorded_execution, tmp_path):
+def test_move(recorded_execution, tmp_path, monkeypatch):
     src = recorded_execution
     src_dir = recorded_execution.parent
     src_files = set([p.name for p in src_dir.iterdir()])
@@ -17,3 +18,16 @@ def test_move(recorded_execution, tmp_path):
     dest_files = set([p.name for p in dst.iterdir()])
     diff = dest_files - src_files
     assert not diff, f"The sets should be empty {diff}"
+
+    dest_json = next(dst.glob("*.json"))
+    written = json.loads(dest_json.read_text())
+    for m in written["Modules"]:
+        assert "/" not in m, f"Module path should be a basename: {m}"
+    for inst in written["instances"].values():
+        assert "/" not in inst["Prologue"], inst["Prologue"]
+        assert "/" not in inst["Epilogue"], inst["Epilogue"]
+
+    foreign_cwd = tmp_path / "elsewhere"
+    foreign_cwd.mkdir()
+    monkeypatch.chdir(foreign_cwd)
+    RecordedExecution.from_json(str(dest_json))

--- a/python/tests/test_record_annotations.py
+++ b/python/tests/test_record_annotations.py
@@ -119,13 +119,19 @@ def test_record_annotations_complex_cases(build_annotation_test_program, tmp_pat
     instances = rr["instances"]
     assert len(instances) >= 2, "Expected at least two dynamic kernel instances"
 
+    # Snapshot paths in the JSON are basenames relative to the JSON's parent.
+    record_dir = json_records[0].resolve().parent
+
+    def _resolve(p):
+        return Path(p) if Path(p).is_absolute() else record_dir / p
+
     saw_in_vec = False
     saw_out_loose = False
     saw_out_tight = False
 
     for instance in instances.values():
-        prologue = Path(instance["Prologue"])
-        epilogue = Path(instance["Epilogue"])
+        prologue = _resolve(instance["Prologue"])
+        epilogue = _resolve(instance["Epilogue"])
         assert prologue.exists(), f"Missing prologue snapshot: {prologue}"
         assert epilogue.exists(), f"Missing epilogue snapshot: {epilogue}"
 

--- a/python/tests/test_record_annotations.py
+++ b/python/tests/test_record_annotations.py
@@ -119,19 +119,15 @@ def test_record_annotations_complex_cases(build_annotation_test_program, tmp_pat
     instances = rr["instances"]
     assert len(instances) >= 2, "Expected at least two dynamic kernel instances"
 
-    # Snapshot paths in the JSON are basenames relative to the JSON's parent.
     record_dir = json_records[0].resolve().parent
-
-    def _resolve(p):
-        return Path(p) if Path(p).is_absolute() else record_dir / p
 
     saw_in_vec = False
     saw_out_loose = False
     saw_out_tight = False
 
     for instance in instances.values():
-        prologue = _resolve(instance["Prologue"])
-        epilogue = _resolve(instance["Epilogue"])
+        prologue = record_dir / instance["Prologue"]
+        epilogue = record_dir / instance["Epilogue"]
         assert prologue.exists(), f"Missing prologue snapshot: {prologue}"
         assert epilogue.exists(), f"Missing epilogue snapshot: {epilogue}"
 

--- a/python/tests/test_recorded_execution.py
+++ b/python/tests/test_recorded_execution.py
@@ -7,6 +7,7 @@ from mneme.recorded_execution import (
     MemStateRef,
     RecordedExecution,
     SnapshotType,
+    _make_path_relative,
 )
 from mneme.mneme_types import dim3
 
@@ -188,6 +189,17 @@ def test_recorded_execution_link_llvm_modules_calls_jit():
 
         fake_link.assert_called_once_with(["a.ll", "b.ll"], "K", True, False)
         assert out == "MOD"
+
+
+def test_make_path_relative_accepts_basename_but_rejects_nested_relative(tmp_path):
+    """
+    The path transform is idempotent for already-relative basenames, but
+    rejects relative paths that would be reinterpreted relative to the JSON file.
+    """
+    assert _make_path_relative("file.epi", tmp_path) == "file.epi"
+
+    with pytest.raises(ValueError, match="Expected absolute path or basename"):
+        _make_path_relative("record-db/file.epi", tmp_path)
 
 
 @pytest.mark.parametrize("path_style", ["basename", "absolute"])

--- a/python/tests/test_recorded_execution.py
+++ b/python/tests/test_recorded_execution.py
@@ -190,12 +190,33 @@ def test_recorded_execution_link_llvm_modules_calls_jit():
         assert out == "MOD"
 
 
-def test_recorded_execution_from_json_reconstructs():
+@pytest.mark.parametrize("path_style", ["basename", "absolute"])
+def test_recorded_execution_from_json_reconstructs(tmp_path, path_style):
+    """
+    from_json must resolve relative path entries against the JSON file's
+    parent directory and pass absolute path entries through unchanged. In
+    both cases, the in-memory paths end up absolute under tmp_path.
+    """
+    mod_path = tmp_path / "modA.ll"
+    pro_path = tmp_path / "file.pro"
+    epi_path = tmp_path / "file.epi"
+    for p in (mod_path, pro_path, epi_path):
+        p.touch()
+
+    if path_style == "basename":
+        modules = [mod_path.name]
+        prologue = pro_path.name
+        epilogue = epi_path.name
+    else:
+        modules = [str(mod_path)]
+        prologue = str(pro_path)
+        epilogue = str(epi_path)
+
     data = {
         "StaticHash": "S",
         "KernelName": "K",
         "DemangledName": "DK",
-        "Modules": ["modA.ll"],
+        "Modules": modules,
         "ArgNames": ["x"],
         "Specializations": [True, True, False],
         "VAddr": "ADDR",
@@ -207,19 +228,16 @@ def test_recorded_execution_from_json_reconstructs():
                 "BlockDims": {"x": 1, "y": 2, "z": 3},
                 "GridDims": {"x": 4, "y": 5, "z": 6},
                 "Occurrences": 3,
-                "Prologue": "file.pro",
-                "Epilogue": "file.epi",
+                "Prologue": prologue,
+                "Epilogue": epilogue,
             }
         },
     }
 
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
-        json.dump(data, f)
-        fname = f.name
+    json_path = tmp_path / "db.json"
+    json_path.write_text(json.dumps(data))
 
-    # Pretend all the module/prologue/epilogue files exist
-    with patch("mneme.recorded_execution.Path.exists", return_value=True):
-        r = RecordedExecution.from_json(fname)
+    r = RecordedExecution.from_json(str(json_path))
 
     assert r.kernel_name == "K"
     assert "H" in r.kernel_instances
@@ -227,5 +245,68 @@ def test_recorded_execution_from_json_reconstructs():
     assert inst.block_dim.x == 1
     assert inst.grid_dim.z == 6
     assert inst.occ == 3
-    assert inst.epilogue.base_prologue_fn == "file.pro"
+
+    assert r.llvm_files == [str(mod_path)]
+    assert inst.prologue.fn == str(pro_path)
+    assert inst.epilogue.fn == str(epi_path)
+    assert inst.epilogue.base_prologue_fn == str(pro_path)
     assert inst.epilogue.s_type == SnapshotType.EPILOGUE
+
+
+@pytest.mark.parametrize("layout", ["in_dir", "out_of_dir"])
+def test_to_json_relativizes_in_dir_files_only(tmp_path, layout):
+    """
+    to_json writes basenames for artifacts in the JSON's parent directory and
+    keeps absolute paths for artifacts outside it.
+    """
+    json_dir = tmp_path / "db"
+    json_dir.mkdir()
+    artifact_dir = json_dir if layout == "in_dir" else (tmp_path / "elsewhere")
+    if layout != "in_dir":
+        artifact_dir.mkdir()
+
+    mod_path = artifact_dir / "mod.bc"
+    pro_path = artifact_dir / "kernel.pro"
+    epi_path = artifact_dir / "kernel.epi"
+    for p in (mod_path, pro_path, epi_path):
+        p.touch()
+
+    instance = RecordedExecution.KernelInstance(
+        static_hash="S",
+        dynamic_hash="H",
+        kernel_name="K",
+        args=[True],
+        shared_mem=0,
+        block_dim=dim3(1, 1, 1),
+        grid_dim=dim3(1, 1, 1),
+        specializations=[True],
+        occ=1,
+        prologue_fn=str(pro_path),
+        epilogue_fn=str(epi_path),
+    )
+
+    r = RecordedExecution(
+        static_hash="S",
+        kernel_name="K",
+        demangled_name="DK",
+        llvm_files=[str(mod_path)],
+        arg_names=["x"],
+        specializations=[True],
+        va_addr="0x100",
+        va_size=64,
+        kernel_instances={"H": instance},
+    )
+
+    json_path = json_dir / "db.json"
+    r.to_json(str(json_path))
+
+    written = json.loads(json_path.read_text())
+
+    if layout == "in_dir":
+        assert written["Modules"] == ["mod.bc"]
+        assert written["instances"]["H"]["Prologue"] == "kernel.pro"
+        assert written["instances"]["H"]["Epilogue"] == "kernel.epi"
+    else:
+        assert written["Modules"] == [str(mod_path)]
+        assert written["instances"]["H"]["Prologue"] == str(pro_path)
+        assert written["instances"]["H"]["Epilogue"] == str(epi_path)

--- a/tests/record/read-record.py
+++ b/tests/record/read-record.py
@@ -84,13 +84,7 @@ data_dir = sys.argv[1] if len(sys.argv) > 1 else "."
 for fn in sorted(glob.glob(os.path.join(data_dir, "*.json"))):
     with open(fn, "r") as fd:
         rr_data = json.load(fd)
-    # Snapshot paths in the JSON may be basenames (relative to the JSON's
-    # parent dir) or absolute paths. Resolve so .exists() works regardless
-    # of cwd.
     base_dir = Path(fn).resolve().parent
-
-    def _resolve(p):
-        return p if Path(p).is_absolute() else str(base_dir / p)
 
     d_name = rr_data["DemangledName"]
     print("DemangledName:", rr_data["DemangledName"])
@@ -111,12 +105,12 @@ for fn in sorted(glob.glob(os.path.join(data_dir, "*.json"))):
                 instance["GridDims"]["z"],
             )
         )
-        prologue_path = _resolve(instance["Prologue"])
-        epilogue_path = _resolve(instance["Epilogue"])
-        if not Path(prologue_path).exists():
+        prologue_path = base_dir / instance["Prologue"]
+        epilogue_path = base_dir / instance["Epilogue"]
+        if not prologue_path.exists():
             print("Expected prologue file to exist")
             sys.exit(-1)
-        if not Path(epilogue_path).exists():
+        if not epilogue_path.exists():
             print("Expected epilogue file to exist")
             sys.exit(-1)
 

--- a/tests/record/read-record.py
+++ b/tests/record/read-record.py
@@ -84,6 +84,14 @@ data_dir = sys.argv[1] if len(sys.argv) > 1 else "."
 for fn in sorted(glob.glob(os.path.join(data_dir, "*.json"))):
     with open(fn, "r") as fd:
         rr_data = json.load(fd)
+    # Snapshot paths in the JSON may be basenames (relative to the JSON's
+    # parent dir) or absolute paths. Resolve so .exists() works regardless
+    # of cwd.
+    base_dir = Path(fn).resolve().parent
+
+    def _resolve(p):
+        return p if Path(p).is_absolute() else str(base_dir / p)
+
     d_name = rr_data["DemangledName"]
     print("DemangledName:", rr_data["DemangledName"])
     print("NumModules:", len(rr_data["Modules"]))
@@ -103,16 +111,18 @@ for fn in sorted(glob.glob(os.path.join(data_dir, "*.json"))):
                 instance["GridDims"]["z"],
             )
         )
-        if not Path(instance["Prologue"]).exists():
+        prologue_path = _resolve(instance["Prologue"])
+        epilogue_path = _resolve(instance["Epilogue"])
+        if not Path(prologue_path).exists():
             print("Expected prologue file to exist")
             sys.exit(-1)
-        if not Path(instance["Epilogue"]).exists():
+        if not Path(epilogue_path).exists():
             print("Expected epilogue file to exist")
             sys.exit(-1)
 
         # Parse the prologue binary to report any non-default blob metadata.
         try:
-            mds = _parse_prologue_metadata(instance["Prologue"])
+            mds = _parse_prologue_metadata(prologue_path)
             for md in mds:
                 if (md["threshold"] != 0.0 or md["builtin"] != 0
                         or md["norm"] != 0 or md["threshold_kind"] != 0


### PR DESCRIPTION
Make recorded Mneme databases relocatable: artifacts that live alongside the record JSON (LLVM IR modules, prologue/epilogue snapshots) are written as basenames and resolved against the JSON's parent directory on load. Plain `cp`/`mv` of the record directory now works without rewriting the JSON. Closes #155.