### PR TITLE
Decouple Mneme and Proteus LLVM

### DIFF
--- a/include/mneme/MnemeRecord.hpp
+++ b/include/mneme/MnemeRecord.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <dlfcn.h>
+#include <optional>
 
 #include "llvm/Support/raw_ostream.h"
 #include <filesystem>
@@ -21,8 +22,7 @@
 #include <llvm/IR/Module.h>
 #include <mutex>
 
-#include <proteus/impl/CompilerInterfaceDevice.h>
-#include <proteus/impl/JitEngineDevice.h>
+#include <proteus/RecordInterface.h>
 
 #include "mneme/DeviceTraits.hpp"
 #include "mneme/MnemeKernelInfo.hpp"
@@ -94,6 +94,51 @@ private:
   bool ExtractedIR;
   RecordDatabase DB;
   std::once_flag ExtractFlag;
+
+  static std::optional<RecordedKernelMetadata>
+  captureProteusKernelMetadata(const void *Kernel) {
+    ProteusRecordedKernel *Record = nullptr;
+    ProteusRecordStatus Status =
+        __proteus_record_capture_kernel(Kernel, &Record);
+    if (Status == PROTEUS_RECORD_KERNEL_NOT_FOUND)
+      return std::nullopt;
+    if (Status != PROTEUS_RECORD_OK || !Record)
+      LOG_FATAL("Proteus failed to capture kernel metadata");
+
+    struct RecordReleaser {
+      void operator()(ProteusRecordedKernel *Record) const {
+        __proteus_record_release_kernel(Record);
+      }
+    };
+    std::unique_ptr<ProteusRecordedKernel, RecordReleaser> RecordOwner(Record);
+
+    const char *KernelName = __proteus_record_kernel_name(Record);
+    if (!KernelName)
+      LOG_FATAL("Proteus recorded kernel has no name");
+
+    RecordedKernelMetadata KInfo;
+    KInfo.Name = KernelName;
+    KInfo.StaticHash.Value = __proteus_record_static_hash(Record);
+
+    const void *BitcodeData = __proteus_record_bitcode_data(Record);
+    size_t BitcodeSize = __proteus_record_bitcode_size(Record);
+    if (!BitcodeData || BitcodeSize == 0)
+      LOG_FATAL("Proteus recorded kernel has empty bitcode");
+    const auto *BitcodeBegin = static_cast<const char *>(BitcodeData);
+    KInfo.Bitcode.Bytes.assign(BitcodeBegin, BitcodeBegin + BitcodeSize);
+
+    size_t NumGlobals = __proteus_record_global_count(Record);
+    for (size_t I = 0; I < NumGlobals; ++I) {
+      ProteusRecordedGlobal Global = __proteus_record_global_at(Record, I);
+      if (!Global.Name)
+        LOG_FATAL("Proteus recorded global has no name");
+      KInfo.BinaryInfo.GlobalVars.try_emplace(
+          Global.Name,
+          RecordedGlobalVar{Global.HostAddr, Global.DevAddr, Global.Size});
+    }
+
+    return KInfo;
+  }
 
   DeviceError_t (*origLaunchKernel)(const void *func, dim3 gridDim,
                                     dim3 blockDim, void **args,
@@ -182,9 +227,6 @@ public:
   DeviceError_t rtLaunchKernel(const void *func, dim3 &GridDim, dim3 &BlockDim,
                                void **Args, size_t SharedMem,
                                DeviceStream_t Stream) {
-    using namespace llvm;
-    using namespace proteus;
-
     if (!PM) {
       // NOTE: We need this arch cause internally we initialize the device.
       // FIXME: We need to have a DeviceTrait function to initialize the GPU
@@ -198,21 +240,18 @@ public:
           DeviceID, (void *)MnemeDeviceRT::getSuggestedAddr());
     }
 
-    auto &Proteus = JitDeviceImplT::instance();
-    auto OptionalKernelInfo = Proteus.getJITKernelInfo(func);
-    // NOTE: Here we do something conceptually different. We no longer go through
-    // proteus. We call immediately the vendor launcher. Thus we avoid overheads from caching etc.
+    // NOTE: Here we do something conceptually different. We no longer go
+    // through proteus. We call immediately the vendor launcher. Thus we avoid
+    // overheads from caching etc.
     LOG_DEBUG("Received OptionalKernel Info {}", (void *)origLaunchKernel);
+    auto OptionalKernelInfo = captureProteusKernelMetadata(func);
     if (!OptionalKernelInfo) {
       LOG_DEBUG("Information for kernel  {} is not included", func);
       return origLaunchKernel(func, GridDim, BlockDim, Args, SharedMem, Stream);
     }
-    auto &KInfo = OptionalKernelInfo.value().get();
+    auto &KInfo = OptionalKernelInfo.value();
     LOG_DEBUG("Continue with {}", KInfo.getName());
-    Proteus.extractModuleAndBitcode(KInfo);
-
-    auto Hash = Proteus.getStaticHash(KInfo);
-    LOG_INFO("Hash value is {}", Hash.getValue());
+    LOG_INFO("Hash value is {}", KInfo.getStaticHash().getValue());
 
     auto RecordAction = DB.takeSnapshot<VendorTypes>(
         PM->getVAStart(), PM->getTotalVASize(), KInfo, AllocatedBlobs, GridDim,
@@ -227,8 +266,7 @@ public:
     auto ret =
         origLaunchKernel(func, GridDim, BlockDim, Args, SharedMem, Stream);
     if (RecordAction) {
-      (*RecordAction)(KInfo.getBinaryInfo().getVarNameToGlobalInfo(),
-                      AllocatedBlobs, Args, Stream);
+      (*RecordAction)(AllocatedBlobs, Args, Stream);
       LOG_INFO("Successfully Recorded Epilogue of Kernel {} NAME:{} GRID:({}, "
                "{}, {}) "
                "BLOCK:({}, {}, "

--- a/include/mneme/MnemeRecord.hpp
+++ b/include/mneme/MnemeRecord.hpp
@@ -194,9 +194,8 @@ public:
           DeviceID, (void *)MnemeDeviceRT::getSuggestedAddr());
     }
 
-    // NOTE: Here we do something conceptually different. We no longer go
-    // through proteus. We call immediately the vendor launcher. Thus we avoid
-    // overheads from caching etc.
+    // NOTE: Here we do something conceptually different. We no longer go through
+    // proteus. We call immediately the vendor launcher. Thus we avoid overheads from caching etc.
     LOG_DEBUG("Received OptionalKernel Info {}", (void *)origLaunchKernel);
     auto OptionalKernelInfo = proteus::runtime::captureKernelMetadata(func);
     if (!OptionalKernelInfo) {

--- a/include/mneme/MnemeRecord.hpp
+++ b/include/mneme/MnemeRecord.hpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <dlfcn.h>
-#include <optional>
 
 #include "llvm/Support/raw_ostream.h"
 #include <filesystem>
@@ -22,7 +21,7 @@
 #include <llvm/IR/Module.h>
 #include <mutex>
 
-#include <proteus/RecordInterface.h>
+#include <proteus/KernelMetadata.h>
 
 #include "mneme/DeviceTraits.hpp"
 #include "mneme/MnemeKernelInfo.hpp"
@@ -94,51 +93,6 @@ private:
   bool ExtractedIR;
   RecordDatabase DB;
   std::once_flag ExtractFlag;
-
-  static std::optional<RecordedKernelMetadata>
-  captureProteusKernelMetadata(const void *Kernel) {
-    ProteusRecordedKernel *Record = nullptr;
-    ProteusRecordStatus Status =
-        __proteus_record_capture_kernel(Kernel, &Record);
-    if (Status == PROTEUS_RECORD_KERNEL_NOT_FOUND)
-      return std::nullopt;
-    if (Status != PROTEUS_RECORD_OK || !Record)
-      LOG_FATAL("Proteus failed to capture kernel metadata");
-
-    struct RecordReleaser {
-      void operator()(ProteusRecordedKernel *Record) const {
-        __proteus_record_release_kernel(Record);
-      }
-    };
-    std::unique_ptr<ProteusRecordedKernel, RecordReleaser> RecordOwner(Record);
-
-    const char *KernelName = __proteus_record_kernel_name(Record);
-    if (!KernelName)
-      LOG_FATAL("Proteus recorded kernel has no name");
-
-    RecordedKernelMetadata KInfo;
-    KInfo.Name = KernelName;
-    KInfo.StaticHash.Value = __proteus_record_static_hash(Record);
-
-    const void *BitcodeData = __proteus_record_bitcode_data(Record);
-    size_t BitcodeSize = __proteus_record_bitcode_size(Record);
-    if (!BitcodeData || BitcodeSize == 0)
-      LOG_FATAL("Proteus recorded kernel has empty bitcode");
-    const auto *BitcodeBegin = static_cast<const char *>(BitcodeData);
-    KInfo.Bitcode.Bytes.assign(BitcodeBegin, BitcodeBegin + BitcodeSize);
-
-    size_t NumGlobals = __proteus_record_global_count(Record);
-    for (size_t I = 0; I < NumGlobals; ++I) {
-      ProteusRecordedGlobal Global = __proteus_record_global_at(Record, I);
-      if (!Global.Name)
-        LOG_FATAL("Proteus recorded global has no name");
-      KInfo.BinaryInfo.GlobalVars.try_emplace(
-          Global.Name,
-          RecordedGlobalVar{Global.HostAddr, Global.DevAddr, Global.Size});
-    }
-
-    return KInfo;
-  }
 
   DeviceError_t (*origLaunchKernel)(const void *func, dim3 gridDim,
                                     dim3 blockDim, void **args,
@@ -244,14 +198,14 @@ public:
     // through proteus. We call immediately the vendor launcher. Thus we avoid
     // overheads from caching etc.
     LOG_DEBUG("Received OptionalKernel Info {}", (void *)origLaunchKernel);
-    auto OptionalKernelInfo = captureProteusKernelMetadata(func);
+    auto OptionalKernelInfo = proteus::runtime::captureKernelMetadata(func);
     if (!OptionalKernelInfo) {
       LOG_DEBUG("Information for kernel  {} is not included", func);
       return origLaunchKernel(func, GridDim, BlockDim, Args, SharedMem, Stream);
     }
     auto &KInfo = OptionalKernelInfo.value();
     LOG_DEBUG("Continue with {}", KInfo.getName());
-    LOG_INFO("Hash value is {}", KInfo.getStaticHash().getValue());
+    LOG_INFO("Hash value is {}", KInfo.getStaticHash());
 
     auto RecordAction = DB.takeSnapshot<VendorTypes>(
         PM->getVAStart(), PM->getTotalVASize(), KInfo, AllocatedBlobs, GridDim,

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -24,10 +24,6 @@
 #include <string>
 #include <sys/types.h>
 
-#include "proteus/impl/CompilerInterfaceDevice.h"
-#include "proteus/impl/Hashing.h"
-#include <proteus/impl/JitEngineDevice.h>
-
 #include "mneme/DeviceTraits.hpp"
 #include "mneme/MnemeConfig.hpp"
 #include "mneme/MnemeKernelInfo.hpp"
@@ -37,6 +33,48 @@
 #include "mneme/MnemeUtils.hpp"
 
 namespace mneme {
+
+struct RecordedGlobalVar {
+  const void *HostAddr;
+  const void *DevAddr;
+  uint64_t VarSize;
+};
+
+using RecordedGlobalVars = std::unordered_map<std::string, RecordedGlobalVar>;
+
+struct RecordedStaticHash {
+  uint64_t Value = 0;
+
+  uint64_t getValue() const { return Value; }
+};
+
+struct RecordedBitcode {
+  std::vector<char> Bytes;
+
+  llvm::StringRef getBuffer() const {
+    return llvm::StringRef(Bytes.data(), Bytes.size());
+  }
+};
+
+struct RecordedBinaryInfo {
+  RecordedGlobalVars GlobalVars;
+
+  const RecordedGlobalVars &getVarNameToGlobalInfo() const {
+    return GlobalVars;
+  }
+};
+
+struct RecordedKernelMetadata {
+  std::string Name;
+  RecordedStaticHash StaticHash;
+  RecordedBitcode Bitcode;
+  RecordedBinaryInfo BinaryInfo;
+
+  const std::string &getName() const { return Name; }
+  RecordedStaticHash getStaticHash() const { return StaticHash; }
+  const RecordedBitcode &getBitcode() const { return Bitcode; }
+  const RecordedBinaryInfo &getBinaryInfo() const { return BinaryInfo; }
+};
 
 struct ReplayGlobalVar {
   void *HostAddr;
@@ -81,7 +119,6 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
   static constexpr size_t DiffMagicSize = sizeof(DiffMagic) - 1;
   static constexpr size_t DiffChunkSize = 1 << 20;
 
-
   static bool isDiffBuffer(llvm::StringRef Buffer) {
     return Buffer.size() >= DiffMagicSize &&
            Buffer.take_front(DiffMagicSize) == llvm::StringRef(DiffMagic);
@@ -93,7 +130,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       LOG_FATAL("Cannot diff buffers with different sizes");
 
     // Count the number of contiguous ranges that have changed between Base and
-    // Current. We want to write out the number of ranges so that the reader 
+    // Current. We want to write out the number of ranges so that the reader
     // can know how many ranges to read.
     size_t Count = 0;
     bool InRange = false;
@@ -119,7 +156,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     if (!UpdateBase.empty() && UpdateBase.size() != Base.size())
       LOG_FATAL("Cannot update diff base with mismatched buffer size");
 
-    // Write out the contiguous ranges that have changed between Base 
+    // Write out the contiguous ranges that have changed between Base
     // and Current.
     size_t Count = 0;
     size_t I = 0;
@@ -145,8 +182,9 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     return Count;
   }
 
-  static void writeCountAndWriteChangedRanges(
-      llvm::raw_ostream &OS, MnemeMemoryBlob<VendorTypes> &Blob) {
+  static void
+  writeCountAndWriteChangedRanges(llvm::raw_ostream &OS,
+                                  MnemeMemoryBlob<VendorTypes> &Blob) {
     auto Size = Blob.getSize();
 
     // early exit
@@ -178,7 +216,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       llvm::ArrayRef<uint8_t> ChunkCurrent(Scratch.get(), ChunkSize);
       llvm::MutableArrayRef<uint8_t> UpdateBase(Base + Offset, ChunkSize);
       NumRanges += writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset,
-                                       UpdateBase);
+                                      UpdateBase);
     }
 
     util::writeScalar(OS, NumRanges);
@@ -290,16 +328,16 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       if (Blob.getActualSize() != ActualSize || Blob.getSize() != Size)
         LOG_FATAL("Mneme diff memory blob size mismatch");
       Blob.setMetadata(MD);
-      applyDiffRanges(
-          CurrentPtr,
-          llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
-                                         Blob.getSize()),
-          NumRanges);
+      applyDiffRanges(CurrentPtr,
+                      llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
+                                                     Blob.getSize()),
+                      NumRanges);
     }
   }
 
 public:
-  using GlobalSnapshotData = std::unordered_map<std::string, std::vector<uint8_t>>;
+  using GlobalSnapshotData =
+      std::unordered_map<std::string, std::vector<uint8_t>>;
 
   static std::pair<std::string, ReplayGlobalVar>
   fromBuffer(const char *&Buffer) {
@@ -316,7 +354,7 @@ public:
   }
 
   std::filesystem::path static takeMnemeBytesSnapshot(
-      std::unordered_map<std::string, proteus::GlobalVarInfo> &GlobalVars,
+      const RecordedGlobalVars &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       std::filesystem::path &Filename,
       llvm::SmallVector<size_t> &KernelArgSizes, void **Args,
@@ -395,7 +433,7 @@ public:
   }
 
   std::filesystem::path static takeMnemeDiffSnapshot(
-      std::unordered_map<std::string, proteus::GlobalVarInfo> &GlobalVars,
+      const RecordedGlobalVars &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       std::filesystem::path &Filename,
       const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
@@ -534,7 +572,7 @@ class KernelInstancesCollection {
 
 private:
   // Parse Proteus's serialized bitcode in a Mneme-owned LLVMContext and
-  // extract per-argument metadata. Operating on a Mneme-owned Module 
+  // extract per-argument metadata. Operating on a Mneme-owned Module
   // keeps Mneme's LLVM runtime from touching any
   // Proteus-owned LLVM C++ object across the DSO boundary.
   void extractArgInfoFromBitcode(llvm::StringRef Bitcode) {
@@ -602,11 +640,11 @@ public:
   }
 
   KernelInstancesCollection(const std::string &MnemeDirectory, void *VAddr,
-                            uint64_t VASize, proteus::JITKernelInfo &KInfo,
+                            uint64_t VASize,
+                            const RecordedKernelMetadata &KInfo,
                             int MaxRecordings)
       : VAddr(VAddr), VASize(VASize), MaxRecordings(MaxRecordings),
         NumRecords(0), KName(KInfo.getName()) {
-    // Non-owning view of Proteus's cached bitcode.
     llvm::StringRef Bitcode = KInfo.getBitcode().getBuffer();
     if (Bitcode.empty())
       LOG_FATAL("Empty bitcode for kernel " + KName);
@@ -630,12 +668,10 @@ public:
 
   template <DeviceVendors VendorTypes>
   std::optional<std::function<
-      void(std::unordered_map<std::string, proteus::GlobalVarInfo> &,
-           llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
+      void(llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
            typename DeviceTraits<VendorTypes>::DeviceStream_t)>>
   takeSnapshot(
-      std::filesystem::path &MnemeDir,
-      std::unordered_map<std::string, proteus::GlobalVarInfo> &GlobalVars,
+      std::filesystem::path &MnemeDir, const RecordedGlobalVars &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       dim3 &GridDim, dim3 &BlockDim, void **Args, size_t SharedMem,
       typename DeviceTraits<VendorTypes>::DeviceStream_t Stream,
@@ -675,15 +711,12 @@ public:
                                           PrologueGlobals.get())
             .string();
 
-    std::function<void(
-        std::unordered_map<std::string, proteus::GlobalVarInfo> &,
-        llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
-        typename DeviceTraits<VendorTypes>::DeviceStream_t)>
+    std::function<void(llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &,
+                       void **,
+                       typename DeviceTraits<VendorTypes>::DeviceStream_t)>
         CaptureEpilogue =
             [this, DynamicHash, StaticHash, MnemeDir, PrologueGlobals,
-             EpilogueType](
-                std::unordered_map<std::string, proteus::GlobalVarInfo>
-                    &GlobalVars,
+             GlobalVars, EpilogueType](
                 llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>>
                     &DeviceMemory,
                 void **Args,
@@ -696,16 +729,16 @@ public:
               switch (EpilogueType) {
               case EpilogueSnapshotType::Bytes:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeBytesSnapshot(
-                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
-                        Args, Stream)
+                    SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory,
+                                                      Filename, KernelArgSizes,
+                                                      Args, Stream)
                         .string();
                 break;
               case EpilogueSnapshotType::Diff:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeDiffSnapshot(
-                        GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
-                        Stream)
+                    SnapshotT::takeMnemeDiffSnapshot(GlobalVars, DeviceMemory,
+                                                     Filename, *PrologueGlobals,
+                                                     Stream)
                         .string();
                 break;
               }
@@ -764,30 +797,27 @@ public:
 
   template <DeviceVendors VendorTypes>
   std::optional<std::function<
-      void(std::unordered_map<std::string, proteus::GlobalVarInfo> &,
-           llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
+      void(llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
            typename DeviceTraits<VendorTypes>::DeviceStream_t)>>
   takeSnapshot(
-      void *VAddr, uint64_t VASize, proteus::JITKernelInfo &KInfo,
+      void *VAddr, uint64_t VASize, const RecordedKernelMetadata &KInfo,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       dim3 &GridDim, dim3 &BlockDim, void **Args, size_t SharedMem,
       typename DeviceTraits<VendorTypes>::DeviceStream_t Stream) {
-    using namespace proteus;
-
     if (!shouldRecord(KInfo.getName())) {
       LOG_INFO("Skip record of Kernel");
       return std::nullopt;
     }
 
+    auto StaticHash = KInfo.getStaticHash().getValue();
     auto IT = KernelRecords.try_emplace(
-        KInfo.getStaticHash().getValue(),
-        KernelInstancesCollection(getDir(), VAddr, VASize, KInfo,
-                                  MaxRecordings));
+        StaticHash, KernelInstancesCollection(getDir(), VAddr, VASize, KInfo,
+                                              MaxRecordings));
     LOG_INFO("Created instance");
     return IT.first->second.takeSnapshot<VendorTypes>(
         MnemeDirectory, KInfo.getBinaryInfo().getVarNameToGlobalInfo(),
-        DeviceMemory, GridDim, BlockDim, Args, SharedMem, Stream,
-        KInfo.getStaticHash().getValue(), EpilogueType);
+        DeviceMemory, GridDim, BlockDim, Args, SharedMem, Stream, StaticHash,
+        EpilogueType);
   }
 
   const std::string getDir() const { return MnemeDirectory.string(); }

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -78,6 +78,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
   static constexpr size_t DiffMagicSize = sizeof(DiffMagic) - 1;
   static constexpr size_t DiffChunkSize = 1 << 20;
 
+
   static bool isDiffBuffer(llvm::StringRef Buffer) {
     return Buffer.size() >= DiffMagicSize &&
            Buffer.take_front(DiffMagicSize) == llvm::StringRef(DiffMagic);
@@ -89,7 +90,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       LOG_FATAL("Cannot diff buffers with different sizes");
 
     // Count the number of contiguous ranges that have changed between Base and
-    // Current. We want to write out the number of ranges so that the reader
+    // Current. We want to write out the number of ranges so that the reader 
     // can know how many ranges to read.
     size_t Count = 0;
     bool InRange = false;
@@ -115,7 +116,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     if (!UpdateBase.empty() && UpdateBase.size() != Base.size())
       LOG_FATAL("Cannot update diff base with mismatched buffer size");
 
-    // Write out the contiguous ranges that have changed between Base
+    // Write out the contiguous ranges that have changed between Base 
     // and Current.
     size_t Count = 0;
     size_t I = 0;
@@ -141,9 +142,8 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     return Count;
   }
 
-  static void
-  writeCountAndWriteChangedRanges(llvm::raw_ostream &OS,
-                                  MnemeMemoryBlob<VendorTypes> &Blob) {
+  static void writeCountAndWriteChangedRanges(
+      llvm::raw_ostream &OS, MnemeMemoryBlob<VendorTypes> &Blob) {
     auto Size = Blob.getSize();
 
     // early exit
@@ -175,7 +175,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       llvm::ArrayRef<uint8_t> ChunkCurrent(Scratch.get(), ChunkSize);
       llvm::MutableArrayRef<uint8_t> UpdateBase(Base + Offset, ChunkSize);
       NumRanges += writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset,
-                                      UpdateBase);
+                                       UpdateBase);
     }
 
     util::writeScalar(OS, NumRanges);
@@ -287,16 +287,16 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       if (Blob.getActualSize() != ActualSize || Blob.getSize() != Size)
         LOG_FATAL("Mneme diff memory blob size mismatch");
       Blob.setMetadata(MD);
-      applyDiffRanges(CurrentPtr,
-                      llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
-                                                     Blob.getSize()),
-                      NumRanges);
+      applyDiffRanges(
+          CurrentPtr,
+          llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
+                                         Blob.getSize()),
+          NumRanges);
     }
   }
 
 public:
-  using GlobalSnapshotData =
-      std::unordered_map<std::string, std::vector<uint8_t>>;
+  using GlobalSnapshotData = std::unordered_map<std::string, std::vector<uint8_t>>;
 
   static std::pair<std::string, ReplayGlobalVar>
   fromBuffer(const char *&Buffer) {
@@ -531,7 +531,7 @@ class KernelInstancesCollection {
 
 private:
   // Parse Proteus's serialized bitcode in a Mneme-owned LLVMContext and
-  // extract per-argument metadata. Operating on a Mneme-owned Module
+  // extract per-argument metadata. Operating on a Mneme-owned Module 
   // keeps Mneme's LLVM runtime from touching any
   // Proteus-owned LLVM C++ object across the DSO boundary.
   void extractArgInfoFromBitcode(llvm::StringRef Bitcode) {
@@ -610,8 +610,8 @@ public:
       LOG_FATAL("Empty bitcode for kernel " + KName);
 
     extractArgInfoFromBitcode(Bitcode);
-    ModuleFiles.emplace_back(
-        StoreModuleBytes(Bitcode, MnemeDirectory, KInfo.getStaticHash()));
+    ModuleFiles.emplace_back(StoreModuleBytes(
+        Bitcode, MnemeDirectory, KInfo.getStaticHash()));
   }
 
   llvm::stable_hash computeHash(dim3 &GridDim, dim3 &BlockDim,
@@ -690,16 +690,16 @@ public:
               switch (EpilogueType) {
               case EpilogueSnapshotType::Bytes:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory,
-                                                      Filename, KernelArgSizes,
-                                                      Args, Stream)
+                    SnapshotT::takeMnemeBytesSnapshot(
+                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
+                        Args, Stream)
                         .string();
                 break;
               case EpilogueSnapshotType::Diff:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeDiffSnapshot(GlobalVars, DeviceMemory,
-                                                     Filename, *PrologueGlobals,
-                                                     Stream)
+                    SnapshotT::takeMnemeDiffSnapshot(
+                        GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
+                        Stream)
                         .string();
                 break;
               }

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -31,50 +31,9 @@
 #include "mneme/MnemeLogger.hpp"
 #include "mneme/MnemeMemory.hpp"
 #include "mneme/MnemeUtils.hpp"
+#include <proteus/KernelMetadata.h>
 
 namespace mneme {
-
-struct RecordedGlobalVar {
-  const void *HostAddr;
-  const void *DevAddr;
-  uint64_t VarSize;
-};
-
-using RecordedGlobalVars = std::unordered_map<std::string, RecordedGlobalVar>;
-
-struct RecordedStaticHash {
-  uint64_t Value = 0;
-
-  uint64_t getValue() const { return Value; }
-};
-
-struct RecordedBitcode {
-  std::vector<char> Bytes;
-
-  llvm::StringRef getBuffer() const {
-    return llvm::StringRef(Bytes.data(), Bytes.size());
-  }
-};
-
-struct RecordedBinaryInfo {
-  RecordedGlobalVars GlobalVars;
-
-  const RecordedGlobalVars &getVarNameToGlobalInfo() const {
-    return GlobalVars;
-  }
-};
-
-struct RecordedKernelMetadata {
-  std::string Name;
-  RecordedStaticHash StaticHash;
-  RecordedBitcode Bitcode;
-  RecordedBinaryInfo BinaryInfo;
-
-  const std::string &getName() const { return Name; }
-  RecordedStaticHash getStaticHash() const { return StaticHash; }
-  const RecordedBitcode &getBitcode() const { return Bitcode; }
-  const RecordedBinaryInfo &getBinaryInfo() const { return BinaryInfo; }
-};
 
 struct ReplayGlobalVar {
   void *HostAddr;
@@ -354,7 +313,7 @@ public:
   }
 
   std::filesystem::path static takeMnemeBytesSnapshot(
-      const RecordedGlobalVars &GlobalVars,
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       std::filesystem::path &Filename,
       llvm::SmallVector<size_t> &KernelArgSizes, void **Args,
@@ -433,7 +392,7 @@ public:
   }
 
   std::filesystem::path static takeMnemeDiffSnapshot(
-      const RecordedGlobalVars &GlobalVars,
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       std::filesystem::path &Filename,
       const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
@@ -641,17 +600,18 @@ public:
 
   KernelInstancesCollection(const std::string &MnemeDirectory, void *VAddr,
                             uint64_t VASize,
-                            const RecordedKernelMetadata &KInfo,
+                            const proteus::runtime::KernelMetadata &KInfo,
                             int MaxRecordings)
       : VAddr(VAddr), VASize(VASize), MaxRecordings(MaxRecordings),
         NumRecords(0), KName(KInfo.getName()) {
-    llvm::StringRef Bitcode = KInfo.getBitcode().getBuffer();
+    const auto &BitcodeBytes = KInfo.getBitcode();
+    llvm::StringRef Bitcode(BitcodeBytes.data(), BitcodeBytes.size());
     if (Bitcode.empty())
       LOG_FATAL("Empty bitcode for kernel " + KName);
 
     extractArgInfoFromBitcode(Bitcode);
-    ModuleFiles.emplace_back(StoreModuleBytes(
-        Bitcode, MnemeDirectory, KInfo.getStaticHash().getValue()));
+    ModuleFiles.emplace_back(
+        StoreModuleBytes(Bitcode, MnemeDirectory, KInfo.getStaticHash()));
   }
 
   llvm::stable_hash computeHash(dim3 &GridDim, dim3 &BlockDim,
@@ -671,7 +631,8 @@ public:
       void(llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
            typename DeviceTraits<VendorTypes>::DeviceStream_t)>>
   takeSnapshot(
-      std::filesystem::path &MnemeDir, const RecordedGlobalVars &GlobalVars,
+      std::filesystem::path &MnemeDir,
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       dim3 &GridDim, dim3 &BlockDim, void **Args, size_t SharedMem,
       typename DeviceTraits<VendorTypes>::DeviceStream_t Stream,
@@ -800,7 +761,8 @@ public:
       void(llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &, void **,
            typename DeviceTraits<VendorTypes>::DeviceStream_t)>>
   takeSnapshot(
-      void *VAddr, uint64_t VASize, const RecordedKernelMetadata &KInfo,
+      void *VAddr, uint64_t VASize,
+      const proteus::runtime::KernelMetadata &KInfo,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       dim3 &GridDim, dim3 &BlockDim, void **Args, size_t SharedMem,
       typename DeviceTraits<VendorTypes>::DeviceStream_t Stream) {
@@ -809,15 +771,14 @@ public:
       return std::nullopt;
     }
 
-    auto StaticHash = KInfo.getStaticHash().getValue();
+    auto StaticHash = KInfo.getStaticHash();
     auto IT = KernelRecords.try_emplace(
         StaticHash, KernelInstancesCollection(getDir(), VAddr, VASize, KInfo,
                                               MaxRecordings));
     LOG_INFO("Created instance");
     return IT.first->second.takeSnapshot<VendorTypes>(
-        MnemeDirectory, KInfo.getBinaryInfo().getVarNameToGlobalInfo(),
-        DeviceMemory, GridDim, BlockDim, Args, SharedMem, Stream, StaticHash,
-        EpilogueType);
+        MnemeDirectory, KInfo.getGlobals(), DeviceMemory, GridDim, BlockDim,
+        Args, SharedMem, Stream, StaticHash, EpilogueType);
   }
 
   const std::string getDir() const { return MnemeDirectory.string(); }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,10 +78,6 @@ endif()
 if(MNEME_ENABLE_HIP)
   target_link_libraries(record PRIVATE hip::host)
   target_link_libraries(record PRIVATE ${llvm_libs})
-  # Proteus's HIP impl headers (CoreLLVMHIP.h) call lld::elf::link inline,
-  # so consumers that instantiate that code must link the LLD libraries
-  # themselves — libproteus.so hides them via its version script.
-  target_link_libraries(record PRIVATE lldCommon lldELF)
 elseif(MNEME_ENABLE_CUDA)
   target_link_libraries(record PRIVATE CUDA::cudart CUDA::cuda_driver)
   target_link_libraries(record PRIVATE ${llvm_libs})

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
 
   Blob.setHostData(std::unique_ptr<uint8_t[]>(new uint8_t[128]));
 
-  proteus::GlobalVarInfo GV(GlobalData.second, GlobalData.first, 128);
+  RecordedGlobalVar GV{GlobalData.second, GlobalData.first, 128};
 
   std::string KernelName("TestKernel");
   std::shared_ptr<KernelInfo> TestKernel =
@@ -90,16 +90,16 @@ int main(int argc, char **argv) {
   TestKernel->setArgSizes(ArgSizes);
 
   // Create a raw_svector_ostream using the buffer
-  std::unordered_map<std::string, proteus::GlobalVarInfo> GVars;
+  RecordedGlobalVars GVars;
   GVars.try_emplace("Test", GV);
   llvm::DenseMap<void *, MnemeMemoryBlobDevice> DeviceMemMap;
   DeviceMemMap.try_emplace((void *)BlobData.first, std::move(Blob));
   std::filesystem::path SnapshotFN("./test.mneme");
 
   MnemeSnapshot<Vendor>::GlobalSnapshotData PrologueGlobals;
-  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(
-      GVars, DeviceMemMap, SnapshotFN, TestKernel->KernelArgSizes, Args, 0,
-      &PrologueGlobals);
+  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(GVars, DeviceMemMap, SnapshotFN,
+                                                TestKernel->KernelArgSizes,
+                                                Args, 0, &PrologueGlobals);
 
   std::unordered_map<std::string, ReplayGlobalVar> ReadGVars;
   llvm::DenseMap<void *, MnemeMemoryBlobDevice> ReadDeviceMemMap;
@@ -232,15 +232,15 @@ int main(int argc, char **argv) {
   GlobalData.second[3] ^= 0x9;
   GlobalData.second[4] ^= 0x13;
 
-  auto EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
-      BlobData.first, BlobData.second, 128,
-      MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  auto EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceCopy(BlobData.first, BlobData.second, 128,
+                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device blob data");
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
-      GlobalData.first, GlobalData.second, 128,
-      MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceCopy(GlobalData.first, GlobalData.second, 128,
+                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device global data");
 
@@ -331,7 +331,8 @@ int main(int argc, char **argv) {
   delete[] GlobalData.second;
   delete[] BlobData.second;
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceFree(GlobalData.first));
+  EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceFree(GlobalData.first));
   if (EC)
     LOG_FATAL("Could not release device memory\n");
 

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
 
   Blob.setHostData(std::unique_ptr<uint8_t[]>(new uint8_t[128]));
 
-  RecordedGlobalVar GV{GlobalData.second, GlobalData.first, 128};
+  proteus::runtime::GlobalMetadata GV{GlobalData.second, GlobalData.first, 128};
 
   std::string KernelName("TestKernel");
   std::shared_ptr<KernelInfo> TestKernel =
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
   TestKernel->setArgSizes(ArgSizes);
 
   // Create a raw_svector_ostream using the buffer
-  RecordedGlobalVars GVars;
+  proteus::runtime::GlobalMetadataMap GVars;
   GVars.try_emplace("Test", GV);
   llvm::DenseMap<void *, MnemeMemoryBlobDevice> DeviceMemMap;
   DeviceMemMap.try_emplace((void *)BlobData.first, std::move(Blob));

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -97,9 +97,9 @@ int main(int argc, char **argv) {
   std::filesystem::path SnapshotFN("./test.mneme");
 
   MnemeSnapshot<Vendor>::GlobalSnapshotData PrologueGlobals;
-  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(GVars, DeviceMemMap, SnapshotFN,
-                                                TestKernel->KernelArgSizes,
-                                                Args, 0, &PrologueGlobals);
+  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(
+      GVars, DeviceMemMap, SnapshotFN, TestKernel->KernelArgSizes, Args, 0,
+      &PrologueGlobals);
 
   std::unordered_map<std::string, ReplayGlobalVar> ReadGVars;
   llvm::DenseMap<void *, MnemeMemoryBlobDevice> ReadDeviceMemMap;
@@ -232,15 +232,15 @@ int main(int argc, char **argv) {
   GlobalData.second[3] ^= 0x9;
   GlobalData.second[4] ^= 0x13;
 
-  auto EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceCopy(BlobData.first, BlobData.second, 128,
-                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  auto EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
+      BlobData.first, BlobData.second, 128,
+      MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device blob data");
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceCopy(GlobalData.first, GlobalData.second, 128,
-                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
+      GlobalData.first, GlobalData.second, 128,
+      MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device global data");
 
@@ -331,8 +331,7 @@ int main(int argc, char **argv) {
   delete[] GlobalData.second;
   delete[] BlobData.second;
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceFree(GlobalData.first));
+  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceFree(GlobalData.first));
   if (EC)
     LOG_FATAL("Could not release device memory\n");
 

--- a/tests/unit_tests/SerializeGlobals.cpp
+++ b/tests/unit_tests/SerializeGlobals.cpp
@@ -17,7 +17,7 @@ void initializeRandomBuffer(uint8_t *Buffer, size_t Size) {
   // Random number generation setup
   std::mt19937 gen(4); // Mersenne Twister random number generator
   std::uniform_int_distribution<uint8_t> dis(
-    0, 255); // Uniform distribution for char range
+      0, 255); // Uniform distribution for char range
 
   // Fill the buffer with random values
   for (int I = 0; I < Size; I++) {
@@ -32,16 +32,16 @@ int main(int argc, char **argv) {
   void *DData;
 
   auto EC = MnemeDeviceRT::DeviceErrorCheck(
-    MnemeDeviceRT::DeviceMalloc((void **)&DData, 128));
+      MnemeDeviceRT::DeviceMalloc((void **)&DData, 128));
   if (EC)
     LOG_FATAL("Could not allocate device data");
 
   EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
-    DData, HData, 128, MnemeDeviceRT::MemcpyHostToDeviceKind()));
+      DData, HData, 128, MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not allocate device data");
 
-  proteus::GlobalVarInfo GV(HData, DData, 128);
+  RecordedGlobalVar GV{HData, DData, 128};
   llvm::SmallVector<char, 128> Buffer;
   std::string VarName("Test");
 
@@ -61,18 +61,18 @@ int main(int argc, char **argv) {
   auto Buff = const_cast<const char *>(Buffer.data());
   auto tmp = mneme::MnemeSnapshot<Vendor>::fromBuffer(Buff);
   auto &GName = tmp.first;
-  auto &GVR   = tmp.second;
+  auto &GVR = tmp.second;
 
   auto Ret = [&]() {
     if (GName != VarName) {
-      std::cerr << "Global Variables differ in name " << GName << " "
-        << GName << "\n";
+      std::cerr << "Global Variables differ in name " << GName << " " << GName
+                << "\n";
       return -1;
     }
 
     if (GVR.VarSize != GV.VarSize) {
       std::cerr << "VarSize differs " << GVR.VarSize << " " << GV.VarSize
-        << "\n";
+                << "\n";
       return -1;
     }
 

--- a/tests/unit_tests/SerializeGlobals.cpp
+++ b/tests/unit_tests/SerializeGlobals.cpp
@@ -17,7 +17,7 @@ void initializeRandomBuffer(uint8_t *Buffer, size_t Size) {
   // Random number generation setup
   std::mt19937 gen(4); // Mersenne Twister random number generator
   std::uniform_int_distribution<uint8_t> dis(
-      0, 255); // Uniform distribution for char range
+    0, 255); // Uniform distribution for char range
 
   // Fill the buffer with random values
   for (int I = 0; I < Size; I++) {
@@ -32,12 +32,12 @@ int main(int argc, char **argv) {
   void *DData;
 
   auto EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceMalloc((void **)&DData, 128));
+    MnemeDeviceRT::DeviceMalloc((void **)&DData, 128));
   if (EC)
     LOG_FATAL("Could not allocate device data");
 
   EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
-      DData, HData, 128, MnemeDeviceRT::MemcpyHostToDeviceKind()));
+    DData, HData, 128, MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not allocate device data");
 
@@ -61,18 +61,18 @@ int main(int argc, char **argv) {
   auto Buff = const_cast<const char *>(Buffer.data());
   auto tmp = mneme::MnemeSnapshot<Vendor>::fromBuffer(Buff);
   auto &GName = tmp.first;
-  auto &GVR = tmp.second;
+  auto &GVR   = tmp.second;
 
   auto Ret = [&]() {
     if (GName != VarName) {
-      std::cerr << "Global Variables differ in name " << GName << " " << GName
-                << "\n";
+      std::cerr << "Global Variables differ in name " << GName << " "
+        << GName << "\n";
       return -1;
     }
 
     if (GVR.VarSize != GV.VarSize) {
       std::cerr << "VarSize differs " << GVR.VarSize << " " << GV.VarSize
-                << "\n";
+        << "\n";
       return -1;
     }
 

--- a/tests/unit_tests/SerializeGlobals.cpp
+++ b/tests/unit_tests/SerializeGlobals.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
   if (EC)
     LOG_FATAL("Could not allocate device data");
 
-  RecordedGlobalVar GV{HData, DData, 128};
+  proteus::runtime::GlobalMetadata GV{HData, DData, 128};
   llvm::SmallVector<char, 128> Buffer;
   std::string VarName("Test");
 


### PR DESCRIPTION
This is a follow-on to #147, which fixed a particular Laghos case I was working with but more DSO issues have been exposed by further Laghos work.

This PR (and the associated proteus one) eliminate sharing of LLVM objects between Proteus and Mneme.
Now, Proteus stores the required information in library-agnostic data structures for Mneme to consume.