### PR TITLE
Skip warmup kernel recordings

### DIFF
--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -91,6 +91,7 @@ public:
 
   const std::optional<std::string> KernelRegex;
   const uint64_t MaxRecordings;
+  const uint64_t SkipRecordings;
   const std::optional<long> PageSizeGiB;
   const LogLevel MnemeLogLevel;
   const EpilogueSnapshotType EpilogueType;
@@ -124,6 +125,8 @@ private:
       : KernelRegex(config_detail::getEnvOrDefaultString("MNEME_RR_KERNELS")),
         MaxRecordings(config_detail::getEnvOrDefaultIntLenient(
             "MNEME_MAX_RECORDINGS", 4)),
+        SkipRecordings(config_detail::getEnvOrDefaultIntLenient(
+            "MNEME_SKIP_RECORDINGS", 0)),
         PageSizeGiB(
             config_detail::getEnvOrDefaultPageSizeGiB("MNEME_PAGE_SIZE")),
         MnemeLogLevel(config_detail::getEnvOrDefaultLogLevel(

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -714,7 +714,9 @@ class RecordDatabase {
   std::string RegexStr;
   bool HasRegex;
   llvm::DenseMap<uint64_t, KernelInstancesCollection> KernelRecords;
+  llvm::DenseMap<uint64_t, uint64_t> KernelLaunchCounts;
   uint64_t MaxRecordings;
+  uint64_t SkipRecordings;
   EpilogueSnapshotType EpilogueType;
 
 public:
@@ -728,6 +730,7 @@ public:
 
     MnemeDirectory = Conf.getDataDirectory();
     MaxRecordings = Conf.MaxRecordings;
+    SkipRecordings = Conf.SkipRecordings;
     EpilogueType = Conf.EpilogueType;
   }
 
@@ -772,6 +775,14 @@ public:
     }
 
     auto StaticHash = KInfo.getStaticHash();
+    uint64_t &LaunchCount = KernelLaunchCounts[StaticHash];
+    LaunchCount++;
+    if (LaunchCount <= SkipRecordings) {
+      LOG_DEBUG("Skipping recording {} of {} for kernel {}", LaunchCount,
+                SkipRecordings, KInfo.getName());
+      return std::nullopt;
+    }
+
     auto IT = KernelRecords.try_emplace(
         StaticHash, KernelInstancesCollection(getDir(), VAddr, VASize, KInfo,
                                               MaxRecordings));

--- a/python/mneme/commands.py
+++ b/python/mneme/commands.py
@@ -236,6 +236,13 @@ class Record:
             help="The maximum number of times to record the same GPU kernel (function) with different dynamic hashes",
         )
         parser.add_argument(
+            "-sr",
+            "--per-kernel-skip-recordings",
+            type=int,
+            default=0,
+            help="The number of matching GPU kernel launches to skip before recording each kernel",
+        )
+        parser.add_argument(
             "--epilogue-format",
             choices=["bytes", "diff"],
             default="bytes",
@@ -265,6 +272,8 @@ class Record:
         record_env["MNEME_PAGE_SIZE"] = str(args.virtual_address_space_size)
         logger.debug(f"MNEME_MAX_RECORDINGS={args.per_kernel_max_recordings}")
         record_env["MNEME_MAX_RECORDINGS"] = str(args.per_kernel_max_recordings)
+        logger.debug(f"MNEME_SKIP_RECORDINGS={args.per_kernel_skip_recordings}")
+        record_env["MNEME_SKIP_RECORDINGS"] = str(args.per_kernel_skip_recordings)
         record_db_dir = Path(args.record_db_dir).resolve()
         if record_db_dir.exists() and not record_db_dir.is_dir():
             raise NotADirectoryError(f"Path '{args.record_db_dir}' is not a directory")

--- a/python/tests/test_cli_record.py
+++ b/python/tests/test_cli_record.py
@@ -63,6 +63,8 @@ def test_record_happy_path(tmp_path, record_parser, monkeypatch):
             "8",
             "--per-kernel-max-recordings",
             "3",
+            "--per-kernel-skip-recordings",
+            "2",
             "--",
             fake_binary,
             "42",
@@ -79,6 +81,7 @@ def test_record_happy_path(tmp_path, record_parser, monkeypatch):
     assert env["LD_PRELOAD"] == fake_lib
     assert env["MNEME_PAGE_SIZE"] == "8"
     assert env["MNEME_MAX_RECORDINGS"] == "3"
+    assert env["MNEME_SKIP_RECORDINGS"] == "2"
     assert env["MNEME_DATA_DIR"] == str(record_dir)
     assert env["MNEME_EPILOGUE_TYPE"] == "bytes"
     assert env["MNEME_LOG_LEVEL"] == "DEBUG"
@@ -256,3 +259,4 @@ def test_record_default_page_size(record_parser, tmp_path, monkeypatch):
     Record.run(args, verbosity=None)
 
     assert captured["env"]["MNEME_PAGE_SIZE"] == "4"  # default from code
+    assert captured["env"]["MNEME_SKIP_RECORDINGS"] == "0"

--- a/tests/record/CMakeLists.txt
+++ b/tests/record/CMakeLists.txt
@@ -119,6 +119,9 @@ CREATE_RDC_GPU_TEST(test_block_grid_2d test_block_grid_2d.cpp)
 CREATE_GPU_TEST(test_block_grid_3d test_block_grid_3d.cpp)
 CREATE_RDC_GPU_TEST(test_block_grid_3d test_block_grid_3d.cpp)
 
+CREATE_GPU_TEST(test_skip_recordings test_skip_recordings.cpp)
+CREATE_RDC_GPU_TEST(test_skip_recordings test_skip_recordings.cpp)
+
 CREATE_GPU_TEST(test_multi_file multi_file1.cpp multi_file2.cpp)
 CREATE_RDC_GPU_TEST(test_multi_file multi_file1.cpp multi_file2.cpp)
 

--- a/tests/record/test_skip_recordings.cpp
+++ b/tests/record/test_skip_recordings.cpp
@@ -1,0 +1,55 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: MNEME_SKIP_RECORDINGS=2 MNEME_MAX_RECORDINGS=2 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_skip_recordings%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: %RR "%t.$$.mneme" | %FILECHECK %s --check-prefix=CHECK-RR
+// RUN: rm -rf "%t.$$.mneme"
+// clang-format on
+
+#include <cstdio>
+#include <iostream>
+
+#include "mneme/DeviceTraits.hpp"
+using namespace mneme;
+
+#ifdef MNEME_ENABLE_HIP
+using MnemeDeviceRT = DeviceTraits<DeviceVendors::HIP>;
+#elif defined(MNEME_ENABLE_CUDA)
+using MnemeDeviceRT = DeviceTraits<DeviceVendors::CUDA>;
+#endif
+
+// CHECK-RR:DemangledName: kernel()
+// CHECK-RR:NumModules: 1
+// CHECK-RR:NumInstances: 2
+__global__ void kernel() {
+  if (threadIdx.x == 0 && blockIdx.x == 0)
+    printf("Kernel launch BlockDim: %d GridDim: %d\n", (int)blockDim.x,
+           (int)gridDim.x);
+}
+
+int main() {
+  for (int tid = 1; tid <= 4; tid++) {
+    dim3 blockDim(tid * 32, 1, 1);
+    dim3 gridDim(tid, 1, 1);
+    kernel<<<gridDim, blockDim>>>();
+    auto EC =
+        MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceSynchronize());
+    if (EC) {
+      std::cout << "Error when running benchmark " << EC.value() << "\n";
+      return -1;
+    }
+  }
+  return 0;
+}
+
+// clang-format off
+// CHECK:Kernel launch BlockDim: 32 GridDim: 1
+// CHECK:Kernel launch BlockDim: 64 GridDim: 2
+// CHECK:Kernel launch BlockDim: 96 GridDim: 3
+// CHECK:Kernel launch BlockDim: 128 GridDim: 4
+
+// CHECK-RR-DAG:BlockDims:(96, 1, 1)
+// CHECK-RR-DAG:GridDims:(3, 1, 1)
+// CHECK-RR-DAG:BlockDims:(128, 1, 1)
+// CHECK-RR-DAG:GridDims:(4, 1, 1)
+
+// clang-format on

--- a/tests/unit_tests/Config.cpp
+++ b/tests/unit_tests/Config.cpp
@@ -24,6 +24,7 @@ void clearMnemeEnv() {
   unsetenv("MNEME_RR_KERNELS");
   unsetenv("MNEME_DATA_DIR");
   unsetenv("MNEME_MAX_RECORDINGS");
+  unsetenv("MNEME_SKIP_RECORDINGS");
   unsetenv("MNEME_PAGE_SIZE");
   unsetenv("MNEME_LOG_LEVEL");
   unsetenv("MNEME_LOG_DIR");
@@ -47,6 +48,8 @@ int main() {
     expect(Conf.getDataDirectory() == std::filesystem::current_path(),
            "MNEME_DATA_DIR should default to current path");
     expect(Conf.MaxRecordings == 4, "MNEME_MAX_RECORDINGS should default to 4");
+    expect(Conf.SkipRecordings == 0,
+           "MNEME_SKIP_RECORDINGS should default to 0");
     expect(!Conf.PageSizeGiB, "MNEME_PAGE_SIZE should default to unset");
     expect(Conf.getPageSizeBytesOrDefault(64) == 64 * GiB,
            "HIP page size fallback should be 64 GiB");
@@ -63,6 +66,7 @@ int main() {
   setenv("MNEME_RR_KERNELS", "_two", 1);
   setenv("MNEME_DATA_DIR", TempDir.c_str(), 1);
   setenv("MNEME_MAX_RECORDINGS", "8", 1);
+  setenv("MNEME_SKIP_RECORDINGS", "2", 1);
   setenv("MNEME_PAGE_SIZE", "3", 1);
   setenv("MNEME_LOG_LEVEL", "debug", 1);
   setenv("MNEME_LOG_DIR", TempDir.c_str(), 1);
@@ -75,6 +79,8 @@ int main() {
            "MNEME_DATA_DIR should use the configured directory");
     expect(Conf.MaxRecordings == 8,
            "MNEME_MAX_RECORDINGS should use the configured value");
+    expect(Conf.SkipRecordings == 2,
+           "MNEME_SKIP_RECORDINGS should use the configured value");
     expect(Conf.PageSizeGiB && *Conf.PageSizeGiB == 3,
            "MNEME_PAGE_SIZE should parse as GiB");
     expect(Conf.getPageSizeBytesOrDefault(64) == 3 * GiB,
@@ -88,12 +94,15 @@ int main() {
   }
 
   setenv("MNEME_MAX_RECORDINGS", "12abc", 1);
+  setenv("MNEME_SKIP_RECORDINGS", "6abc", 1);
   setenv("MNEME_PAGE_SIZE", "5abc", 1);
   setenv("MNEME_LOG_LEVEL", "verbose", 1);
   {
     auto Conf = Config::createFromEnvironment();
     expect(Conf.MaxRecordings == 12,
            "MNEME_MAX_RECORDINGS should keep atoi-style parsing");
+    expect(Conf.SkipRecordings == 6,
+           "MNEME_SKIP_RECORDINGS should keep atoi-style parsing");
     expect(Conf.PageSizeGiB && *Conf.PageSizeGiB == 5,
            "MNEME_PAGE_SIZE should keep atol-style parsing");
     expect(Conf.MnemeLogLevel == LogLevel::Info,
@@ -101,12 +110,15 @@ int main() {
   }
 
   setenv("MNEME_MAX_RECORDINGS", "abc", 1);
+  setenv("MNEME_SKIP_RECORDINGS", "abc", 1);
   setenv("MNEME_PAGE_SIZE", "abc", 1);
   setenv("MNEME_EPILOGUE_TYPE", "bytes", 1);
   {
     auto Conf = Config::createFromEnvironment();
     expect(Conf.MaxRecordings == 0,
            "invalid MNEME_MAX_RECORDINGS should parse to 0");
+    expect(Conf.SkipRecordings == 0,
+           "invalid MNEME_SKIP_RECORDINGS should parse to 0");
     expect(Conf.PageSizeGiB && *Conf.PageSizeGiB == 0,
            "invalid MNEME_PAGE_SIZE should parse to 0");
     expect(Conf.EpilogueType == EpilogueSnapshotType::Bytes,


### PR DESCRIPTION
Adds per-kernel warmup skipping before Mneme starts recording dynamic kernel instances.

- Add MNEME_SKIP_RECORDINGS native config and apply it per static kernel after kernel regex filtering.
- Add mneme record -sr/--per-kernel-skip-recordings to set the runtime env var.
- Cover config parsing, CLI env propagation, and HIP record/RDC behavior with a new skip-recordings lit test.