### PR TITLE
Default epilogue snapshots to diff

### DIFF
--- a/docs/usage/artifacts.md
+++ b/docs/usage/artifacts.md
@@ -106,17 +106,17 @@ experimentation.
 
 The prologue file contains a full serialized snapshot of GPU memory,
 global variables, metadata, and kernel argument mappings. By default,
-the epilogue file is also stored as a full byte snapshot of the
-post-kernel state.
+the epilogue file is stored as a binary diff against the matching
+prologue.
 
-Epilogue snapshots can optionally be stored as binary diffs against the
-matching prologue by recording with:
+The default format is equivalent to:
 
 ```bash
 mneme record --epilogue-format diff -- <application> [args...]
 ```
 
-The default format is equivalent to:
+Epilogue snapshots can still be stored as full byte snapshots by
+recording with:
 
 ```bash
 mneme record --epilogue-format bytes -- <application> [args...]

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -48,6 +48,7 @@ artifact.
 | `-rdb`, `--record-db-dir`               | Path to a **existing** directory where recorded artifacts (metadata, LLVM IR, and device memory snapshots) will be stored |
 | `-vass`, `--virtual-address-space-size` | Size (in **GB**) of the virtual address space allocated by Mneme for recording                                            |
 | `-mr`, `--per-kernel-max-recordings`    | Maximum number of times the same GPU kernel may be recorded with different dynamic hashes                                 |
+| `--epilogue-format`                     | Store epilogue snapshots as `diff` or `bytes`; defaults to `diff`                                                        |
 | `-rr`, `--record-ranks`                 | Restrict recording to a comma-separated set of MPI ranks (e.g. `0`, `0,1,3`) or `all` for every rank. See *Multi-rank recording* below. |
 | `-h`, `--help`                          | Show help message and exit                                                                                                |
 

--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -227,7 +227,7 @@ private:
         MnemeLogLevel(config_detail::getEnvOrDefaultLogLevel(
             "MNEME_LOG_LEVEL", LogLevel::Critical)),
         EpilogueType(config_detail::getEnvOrDefaultEpilogueSnapshotType(
-            "MNEME_EPILOGUE_TYPE", EpilogueSnapshotType::Bytes)),
+            "MNEME_EPILOGUE_TYPE", EpilogueSnapshotType::Diff)),
         MnemeDataDir(config_detail::getEnvOrDefaultString("MNEME_DATA_DIR")),
         MnemeLogDir(config_detail::getEnvOrDefaultString("MNEME_LOG_DIR")),
         RecordingEnabledThisRank(

--- a/python/mneme/commands.py
+++ b/python/mneme/commands.py
@@ -245,7 +245,7 @@ class Record:
         parser.add_argument(
             "--epilogue-format",
             choices=["bytes", "diff"],
-            default="bytes",
+            default="diff",
             help="The format to use when saving epilogue snapshots, either as full bytes or as diffs from the prologue",
         )
         parser.add_argument(

--- a/python/tests/test_cli_record.py
+++ b/python/tests/test_cli_record.py
@@ -83,12 +83,12 @@ def test_record_happy_path(tmp_path, record_parser, monkeypatch):
     assert env["MNEME_MAX_RECORDINGS"] == "3"
     assert env["MNEME_SKIP_RECORDINGS"] == "2"
     assert env["MNEME_DATA_DIR"] == str(record_dir)
-    assert env["MNEME_EPILOGUE_TYPE"] == "bytes"
+    assert env["MNEME_EPILOGUE_TYPE"] == "diff"
     assert env["MNEME_LOG_LEVEL"] == "DEBUG"
 
 
 def test_record_epilogue_format_sets_env(tmp_path, record_parser, monkeypatch):
-    """--epilogue-format controls the MNEME_EPILOGUE_TYPE runtime config."""
+    """--epilogue-format overrides the MNEME_EPILOGUE_TYPE runtime config."""
     record_dir = tmp_path / "records"
     record_dir.mkdir()
 
@@ -110,7 +110,7 @@ def test_record_epilogue_format_sets_env(tmp_path, record_parser, monkeypatch):
             "--record-db-dir",
             str(record_dir),
             "--epilogue-format",
-            "diff",
+            "bytes",
             "--",
             "/usr/bin/true",
         ]
@@ -118,7 +118,7 @@ def test_record_epilogue_format_sets_env(tmp_path, record_parser, monkeypatch):
 
     Record.run(args, verbosity=None)
 
-    assert captured["env"]["MNEME_EPILOGUE_TYPE"] == "diff"
+    assert captured["env"]["MNEME_EPILOGUE_TYPE"] == "bytes"
 
 
 def test_record_rejects_invalid_epilogue_format(record_parser):

--- a/tests/unit_tests/Config.cpp
+++ b/tests/unit_tests/Config.cpp
@@ -74,8 +74,8 @@ int main() {
     expect(Conf.MnemeLogLevel == LogLevel::Critical,
            "MNEME_LOG_LEVEL should default to critical");
     expect(!Conf.getLogDirectory(), "MNEME_LOG_DIR should default to unset");
-    expect(Conf.EpilogueType == EpilogueSnapshotType::Bytes,
-           "MNEME_EPILOGUE_TYPE should default to bytes");
+    expect(Conf.EpilogueType == EpilogueSnapshotType::Diff,
+           "MNEME_EPILOGUE_TYPE should default to diff");
   }
 
   auto TempDir = makeTempDir();


### PR DESCRIPTION
I was wrong about the space savings of `diff` relative to `bytes`.
In my experiments, `diff` is strictly better.

Default epilogue snapshot recording to diff format while keeping bytes available as an explicit override.

- Change native config and Python CLI defaults from bytes to diff
- Keep explicit bytes and diff epilogue format handling covered by tests
- Update artifact and CLI docs to describe diff as the default format