### PR TITLE
Fix spurious error in rtSetDevice

### DIFF
--- a/include/mneme/MnemeRecordingBackend.hpp
+++ b/include/mneme/MnemeRecordingBackend.hpp
@@ -189,6 +189,8 @@ public:
       DeviceID = deviceID;
     } else if (PM == nullptr) {
       DeviceID = deviceID;
+    } else if (deviceID == DeviceID) {
+      // no change; ignore
     } else if (DeviceID != -1 && PM != nullptr) {
       LOG_CRITICAL("Setting Device ID although it already "
                    "set and memory is "


### PR DESCRIPTION
If rtSetDevice was called with the same device id as originally set, Mneme would throw a critical error even though it's a no-op.