### PR TITLE
Prevent crash on exit from unreleased memory blobs

### DIFF
--- a/include/mneme/MnemeMemory.hpp
+++ b/include/mneme/MnemeMemory.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <llvm/ADT/StringRef.h>
@@ -32,12 +33,20 @@ protected:
   uint64_t Size;
   std::unique_ptr<uint8_t[]> HostData;
   bool IsMapped;
+  uint64_t blob_id;  // Unique ID for tracking
+
+  static std::atomic<uint64_t> next_blob_id;
+
+  uint64_t allocate_blob_id() {
+    return next_blob_id.fetch_add(1, std::memory_order_relaxed);
+  }
 
 public:
   MnemeMemoryBlob(uint64_t ActualSize = 0, void *BlobAddr = nullptr,
                   uint64_t Size = 0)
       : ActualSize(ActualSize), BlobAddr(BlobAddr), Size(Size),
-        HostData(new uint8_t[Size]), IsMapped(false) {}
+        HostData(new uint8_t[Size]), IsMapped(false), blob_id(allocate_blob_id()) {
+  }
 
   DeviceError_t map(void *VA, uint64_t ActualSize, uint64_t Size) {
     this->Size = Size;
@@ -61,8 +70,9 @@ public:
   }
 
   DeviceError_t release() {
-    if (!BlobAddr)
+    if (!BlobAddr) {
       return MnemeDeviceRT::DeviceSuccess;
+    }
 
     if (!IsMapped) {
       auto ret = MnemeDeviceRT::DeviceFree(BlobAddr);
@@ -79,7 +89,8 @@ public:
 
   ~MnemeMemoryBlob() {
     if (BlobAddr != 0 && IsMapped) {
-      LOG_FATAL("Destroying memory descriptor without releasing device memory");
+      LOG_FATAL("[BLOB-{}] Destroying memory descriptor without releasing device memory at addr={}, size={}",
+                blob_id, (void*)BlobAddr, Size);
     }
   }
 
@@ -195,4 +206,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 
   return OS;
 }
+
+template <DeviceVendors VendorTypes>
+std::atomic<uint64_t> MnemeMemoryBlob<VendorTypes>::next_blob_id{0};
+
 } // namespace mneme

--- a/include/mneme/MnemeRecordingBackend.hpp
+++ b/include/mneme/MnemeRecordingBackend.hpp
@@ -200,6 +200,25 @@ public:
   DeviceError_t rtGetDevice(int *deviceID) override {
     return Runtime.origGetDeviceID(deviceID);
   }
+
+  ~RecordingBackend() {
+    LOG_DEBUG("RecordingBackend destructor: releasing {} blobs", AllocatedBlobs.size());
+
+    // Release all unreleased blobs before the DenseMap destructs
+    for (auto &Entry : AllocatedBlobs) {
+      auto &Blob = Entry.second;
+      if (Blob.getBlobAddr() != nullptr) {
+        LOG_DEBUG("Releasing blob at addr={} during recorder cleanup",
+                  Blob.getBlobAddr());
+        Blob.release();
+      }
+    }
+
+    if (PM)
+      PM.reset();
+
+    LOG_DEBUG("RecordingBackend destructor complete");
+  }
 };
 
 } // namespace mneme


### PR DESCRIPTION
Adds a destructor to RecordingBackend to release unreleased blobs before the implicit destruction of DenseMap.

Previously, if the MnemeMemoryBlob destructor encountered unreleased blobs, it would abort. 
https://github.com/Olympus-HPC/Mneme/blob/703b65eafd609b010611594a8515d85465a8eaee/include/mneme/MnemeMemory.hpp#L80-L84

This just ensures that any blobs are properly released before destruction.