### PR TITLE
Prevent crash on exit from released Backend

### DIFF
--- a/include/mneme/MnemeRecord.hpp
+++ b/include/mneme/MnemeRecord.hpp
@@ -29,45 +29,67 @@ public:
   }
 
   bool setMetadataForPointer(const void *ptr, Metadata md) {
+    if (!Backend) return false;
     return Backend->setMetadataForPointer(ptr, std::move(md));
   }
 
   bool getMetadataForPointer(const void *ptr, Metadata &md) const {
+    if (!Backend) return false;
     return Backend->getMetadataForPointer(ptr, md);
   }
 
   bool eraseMetadataForPointer(const void *ptr) {
+    if (!Backend) return false;
     return Backend->eraseMetadataForPointer(ptr);
   }
 
   DeviceError_t rtMalloc(void **ptr, size_t size) {
+    if (!Backend) return MnemeDeviceRT::DeviceSuccess;
     return Backend->rtMalloc(ptr, size);
   }
 
   DeviceError_t rtManagedMalloc(void **ptr, size_t size, unsigned int flags) {
+    if (!Backend) return MnemeDeviceRT::DeviceSuccess;
     return Backend->rtManagedMalloc(ptr, size, flags);
   }
 
   DeviceError_t rtHostMalloc(void **ptr, size_t size, unsigned int flags) {
+    if (!Backend) return MnemeDeviceRT::DeviceSuccess;
     return Backend->rtHostMalloc(ptr, size, flags);
   }
 
-  DeviceError_t rtFree(void *ptr) { return Backend->rtFree(ptr); }
+  DeviceError_t rtFree(void *ptr) {
+    if (!Backend) return MnemeDeviceRT::DeviceSuccess;
+    return Backend->rtFree(ptr);
+  }
 
-  DeviceError_t rtHostFree(void *ptr) { return Backend->rtHostFree(ptr); }
+  DeviceError_t rtHostFree(void *ptr) {
+    if (!Backend) return MnemeDeviceRT::DeviceSuccess;
+    return Backend->rtHostFree(ptr);
+  }
 
   DeviceError_t rtLaunchKernel(const void *func, dim3 &GridDim, dim3 &BlockDim,
                                void **Args, size_t SharedMem,
                                DeviceStream_t Stream) {
+    if (!Backend) return MnemeDeviceRT::DeviceSuccess;
     return Backend->rtLaunchKernel(func, GridDim, BlockDim, Args, SharedMem,
                                    Stream);
   }
 
   DeviceError_t rtSetDevice(int deviceID) {
+    if (!Backend) {
+      // Backend destroyed during shutdown - return success
+      return MnemeDeviceRT::DeviceSuccess;
+    }
     return Backend->rtSetDevice(deviceID);
   }
 
   DeviceError_t rtGetDevice(int *deviceID) {
+    if (!Backend) {
+      // Backend destroyed during shutdown - set device to 0 and return success
+      if (deviceID) *deviceID = 0;
+      return MnemeDeviceRT::DeviceSuccess;
+    }
     return Backend->rtGetDevice(deviceID);
   }
 };


### PR DESCRIPTION
During shutdown in some programs, Umpire's resource manager destructor calls HIP functions, which causes crashes if Backend has already been destroyed.

Now, Backend is checked before any dereferencing, allowing a smooth exit during shutdown.