### PR TITLE
Add signal handler during record

### DIFF
--- a/include/mneme/MnemeCrashHandler.hpp
+++ b/include/mneme/MnemeCrashHandler.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace mneme {
+
+/// Install a handler for fatal signals (SIGSEGV, SIGABRT, SIGFPE, SIGILL,
+/// SIGBUS) that writes an async-signal-safe banner to stderr and then re-raises
+/// the signal so its default action (core dump / termination) still runs.
+///
+/// Intended to be called once after main has started — e.g. from a recorder
+/// singleton constructor — so that a crash while mneme is recording is clearly
+/// attributed instead of producing a bare core dump. Repeated calls are no-ops.
+void installCrashHandler();
+
+} // namespace mneme

--- a/include/mneme/MnemeCrashHandler.hpp
+++ b/include/mneme/MnemeCrashHandler.hpp
@@ -2,13 +2,8 @@
 
 namespace mneme {
 
-/// Install a handler for fatal signals (SIGSEGV, SIGABRT, SIGFPE, SIGILL,
-/// SIGBUS) that writes an async-signal-safe banner to stderr and then re-raises
-/// the signal so its default action (core dump / termination) still runs.
-///
-/// Intended to be called once after main has started — e.g. from a recorder
-/// singleton constructor — so that a crash while mneme is recording is clearly
-/// attributed instead of producing a bare core dump. Repeated calls are no-ops.
+// Install a fatal-signal handler so a crash during recording is reported
+// instead of producing a bare core dump. Repeated calls are no-ops.
 void installCrashHandler();
 
 } // namespace mneme

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 set(MnemeCoreSrcDir ${CMAKE_CURRENT_SOURCE_DIR})
 set(AnnotationRuntimeSRC MnemeAnnotation.cpp)
-set(RecordLibSRC MnemeAnnotationInternal.cpp)
+set(RecordLibSRC MnemeAnnotationInternal.cpp MnemeCrashHandler.cpp)
 set(ReplaySRC MnemeReplay.cpp MnemePageManager.cpp MnemeDeviceCode.cpp MnemeAnnotationInternal.cpp)
 
 if (MNEME_ENABLE_HIP)

--- a/src/MnemeCrashHandler.cpp
+++ b/src/MnemeCrashHandler.cpp
@@ -11,27 +11,25 @@ namespace mneme {
 namespace {
 
 void crashSignalHandler(int Signal) {
-  // A second fatal signal (possibly on another thread) must not re-enter the
-  // handler; bail straight to _exit with the conventional 128 + signal code.
+  // A nested or concurrent fatal signal must not re-enter the handler.
   static std::atomic_flag InHandler = ATOMIC_FLAG_INIT;
   if (InHandler.test_and_set())
     _exit(128 + Signal);
 
-  // Only async-signal-safe functions are allowed here. spdlog/iostream are NOT
-  // safe, especially during program teardown.
+  // Only async-signal-safe functions are allowed here; spdlog and iostream are
+  // not, particularly during program teardown.
   static constexpr char Msg[] = "=== PROGRAM CRASHED (see core dump) ===\n";
   (void)!write(STDERR_FILENO, Msg, sizeof(Msg) - 1);
 
-  // SA_RESETHAND already restored SIG_DFL, so re-raising runs the default
-  // action (core dump / termination) for the signal we trapped.
+  // SA_RESETHAND already restored SIG_DFL, so re-raising takes the default
+  // action and dumps core.
   std::raise(Signal);
 }
 
 } // namespace
 
 void installCrashHandler() {
-  // The recorder singleton constructs once per process, but guard anyway so the
-  // handler is never installed twice.
+  // Ensure repeated calls are no-ops.
   static std::atomic_flag Installed = ATOMIC_FLAG_INIT;
   if (Installed.test_and_set())
     return;

--- a/src/MnemeCrashHandler.cpp
+++ b/src/MnemeCrashHandler.cpp
@@ -1,0 +1,47 @@
+#include "mneme/MnemeCrashHandler.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <cstdlib>
+#include <initializer_list>
+#include <unistd.h>
+
+namespace mneme {
+
+namespace {
+
+void crashSignalHandler(int Signal) {
+  // A second fatal signal (possibly on another thread) must not re-enter the
+  // handler; bail straight to _exit with the conventional 128 + signal code.
+  static std::atomic_flag InHandler = ATOMIC_FLAG_INIT;
+  if (InHandler.test_and_set())
+    _exit(128 + Signal);
+
+  // Only async-signal-safe functions are allowed here. spdlog/iostream are NOT
+  // safe, especially during program teardown.
+  static constexpr char Msg[] = "=== PROGRAM CRASHED (see core dump) ===\n";
+  (void)!write(STDERR_FILENO, Msg, sizeof(Msg) - 1);
+
+  // SA_RESETHAND already restored SIG_DFL, so re-raising runs the default
+  // action (core dump / termination) for the signal we trapped.
+  std::raise(Signal);
+}
+
+} // namespace
+
+void installCrashHandler() {
+  // The recorder singleton constructs once per process, but guard anyway so the
+  // handler is never installed twice.
+  static std::atomic_flag Installed = ATOMIC_FLAG_INIT;
+  if (Installed.test_and_set())
+    return;
+
+  struct sigaction SigAction {};
+  SigAction.sa_handler = crashSignalHandler;
+  sigemptyset(&SigAction.sa_mask);
+  SigAction.sa_flags = SA_RESETHAND;
+  for (int Sig : {SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS})
+    sigaction(Sig, &SigAction, nullptr);
+}
+
+} // namespace mneme

--- a/src/MnemeRecordPreloadCUDA.cpp
+++ b/src/MnemeRecordPreloadCUDA.cpp
@@ -1,4 +1,5 @@
 #include "MnemeAnnotationRuntime.hpp"
+#include "mneme/MnemeCrashHandler.hpp"
 #include "mneme/MnemeLLVMUtils.hpp"
 #include "mneme/MnemeLogger.hpp"
 #include "mneme/MnemeRecord.hpp"
@@ -24,6 +25,8 @@ private:
     // the initialization/de-initialization order.
     // FIXME: Fix de-init fiasco order in some proper way
     LOG_DEBUG("Initializing preloaded library");
+    // Installed on the first intercepted CUDA call, i.e. after main has started.
+    installCrashHandler();
   }
 
 public:

--- a/src/MnemeRecordPreloadHIP.cpp
+++ b/src/MnemeRecordPreloadHIP.cpp
@@ -5,8 +5,36 @@
 #include "mneme/MnemeRecord.hpp"
 #include <hip/hip_runtime.h>
 #include <utility>
+#include <csignal>
+#include <cstdlib>
+#include <unistd.h>
+#include <atomic>
 
 using namespace mneme;
+
+
+static void signal_handler(int signal) {
+  static std::atomic_flag in_handler = ATOMIC_FLAG_INIT;
+  if (in_handler.test_and_set()) _exit(128 + signal);
+
+  // Only use async-signal-safe functions in signal handlers
+  // spdlog is NOT safe to use here, especially during program exit
+  const char msg[] = "=== PROGRAM CRASHED (see core dump) ===\n";
+  write(STDERR_FILENO, msg, sizeof(msg) - 1);
+
+  // SA_RESETHAND already restored SIG_DFL; just re-raise for the core dump.
+  std::raise(signal);
+}
+
+static void install_crash_handler() {
+  struct sigaction sa;
+  sa.sa_handler = signal_handler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = SA_RESETHAND;
+  for (int sig : {SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS}) {
+    sigaction(sig, &sa, nullptr);
+  }
+}
 
 class MnemeRecorderHIPPreload
     : public MnemeRecorder<mneme::DeviceVendors::HIP> {
@@ -14,6 +42,11 @@ private:
   static constexpr bool hasFatBinEnd = false;
   MnemeRecorderHIPPreload(MnemeRecorderHIPPreload &) = delete;
   MnemeRecorderHIPPreload(MnemeRecorderHIPPreload &&) = delete;
+
+  MnemeRecorderHIPPreload() {
+    // install crash handler on first HIP call (after main has started)
+    install_crash_handler();
+  }
 
 public:
   static MnemeRecorderHIPPreload &instance() {
@@ -57,7 +90,8 @@ hipError_t hipHostFree(void *ptr) {
 hipError_t hipSetDevice(int deviceID) {
   LOG_DEBUG("Entering Mneme to set Device");
   auto &mneme = MnemeRecorderHIPPreload::instance();
-  return mneme.rtSetDevice(deviceID);
+  auto result = mneme.rtSetDevice(deviceID);
+  return result;
 }
 
 hipError_t hipGetDevice(int *deviceID) {
@@ -71,8 +105,10 @@ hipError_t __proteus_launch_kernel(void *Kernel, dim3 GridDim, dim3 BlockDim,
                                void *Stream) {
   LOG_DEBUG("Enetering Mneme to launch kernel");
   auto &mneme = MnemeRecorderHIPPreload::instance();
-  return mneme.rtLaunchKernel(Kernel, GridDim, BlockDim, KernelArgs, ShmemSize,
-                              static_cast<hipStream_t>(Stream));
+  auto result = mneme.rtLaunchKernel(Kernel, GridDim, BlockDim, KernelArgs, ShmemSize,
+                                     static_cast<hipStream_t>(Stream));
+
+  return result;
 }
 
 bool mneme_set_metadata_for_ptr(const void *ptr, mneme::Metadata md) {

--- a/src/MnemeRecordPreloadHIP.cpp
+++ b/src/MnemeRecordPreloadHIP.cpp
@@ -1,40 +1,13 @@
 #include "MnemeAnnotationRuntime.hpp"
 #include "mneme/DeviceTraits.hpp"
+#include "mneme/MnemeCrashHandler.hpp"
 #include "mneme/MnemeLLVMUtils.hpp"
 #include "mneme/MnemeLogger.hpp"
 #include "mneme/MnemeRecord.hpp"
 #include <hip/hip_runtime.h>
 #include <utility>
-#include <csignal>
-#include <cstdlib>
-#include <unistd.h>
-#include <atomic>
 
 using namespace mneme;
-
-
-static void signal_handler(int signal) {
-  static std::atomic_flag in_handler = ATOMIC_FLAG_INIT;
-  if (in_handler.test_and_set()) _exit(128 + signal);
-
-  // Only use async-signal-safe functions in signal handlers
-  // spdlog is NOT safe to use here, especially during program exit
-  const char msg[] = "=== PROGRAM CRASHED (see core dump) ===\n";
-  write(STDERR_FILENO, msg, sizeof(msg) - 1);
-
-  // SA_RESETHAND already restored SIG_DFL; just re-raise for the core dump.
-  std::raise(signal);
-}
-
-static void install_crash_handler() {
-  struct sigaction sa;
-  sa.sa_handler = signal_handler;
-  sigemptyset(&sa.sa_mask);
-  sa.sa_flags = SA_RESETHAND;
-  for (int sig : {SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS}) {
-    sigaction(sig, &sa, nullptr);
-  }
-}
 
 class MnemeRecorderHIPPreload
     : public MnemeRecorder<mneme::DeviceVendors::HIP> {
@@ -44,8 +17,8 @@ private:
   MnemeRecorderHIPPreload(MnemeRecorderHIPPreload &&) = delete;
 
   MnemeRecorderHIPPreload() {
-    // install crash handler on first HIP call (after main has started)
-    install_crash_handler();
+    // Installed on the first intercepted HIP call, i.e. after main has started.
+    installCrashHandler();
   }
 
 public:
@@ -90,8 +63,7 @@ hipError_t hipHostFree(void *ptr) {
 hipError_t hipSetDevice(int deviceID) {
   LOG_DEBUG("Entering Mneme to set Device");
   auto &mneme = MnemeRecorderHIPPreload::instance();
-  auto result = mneme.rtSetDevice(deviceID);
-  return result;
+  return mneme.rtSetDevice(deviceID);
 }
 
 hipError_t hipGetDevice(int *deviceID) {
@@ -105,10 +77,8 @@ hipError_t __proteus_launch_kernel(void *Kernel, dim3 GridDim, dim3 BlockDim,
                                void *Stream) {
   LOG_DEBUG("Enetering Mneme to launch kernel");
   auto &mneme = MnemeRecorderHIPPreload::instance();
-  auto result = mneme.rtLaunchKernel(Kernel, GridDim, BlockDim, KernelArgs, ShmemSize,
-                                     static_cast<hipStream_t>(Stream));
-
-  return result;
+  return mneme.rtLaunchKernel(Kernel, GridDim, BlockDim, KernelArgs, ShmemSize,
+                              static_cast<hipStream_t>(Stream));
 }
 
 bool mneme_set_metadata_for_ptr(const void *ptr, mneme::Metadata md) {

--- a/tests/record/CMakeLists.txt
+++ b/tests/record/CMakeLists.txt
@@ -136,3 +136,5 @@ CREATE_RDC_GPU_TEST(multi_kernel_regex multi_kernel_regex.cpp)
 
 CREATE_GPU_TEST(test_annotation test_annotation.cpp)
 CREATE_RDC_GPU_TEST(test_annotation test_annotation.cpp)
+
+CREATE_GPU_TEST(test_crash_handling test_crash_handling.cpp)

--- a/tests/record/test_crash_handling.cpp
+++ b/tests/record/test_crash_handling.cpp
@@ -5,8 +5,10 @@
 // RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
-// Test that signal handler is installed and catches crashes during mneme recording
-// This test verifies the functionality added in commit c3967ac
+// The mneme preload library installs a crash handler when its recorder
+// singleton is first constructed. This test launches a kernel (constructing the
+// singleton) and then dereferences a null pointer: the handler should print the
+// crash banner to stderr before the re-raised signal terminates the process.
 
 #include <climits>
 #include <cstdio>

--- a/tests/record/test_crash_handling.cpp
+++ b/tests/record/test_crash_handling.cpp
@@ -5,10 +5,8 @@
 // RUN: rm -rf "%t.$$.mneme"
 // clang-format on
 
-// The mneme preload library installs a crash handler when its recorder
-// singleton is first constructed. This test launches a kernel (constructing the
-// singleton) and then dereferences a null pointer: the handler should print the
-// crash banner to stderr before the re-raised signal terminates the process.
+// A crash while mneme is recording should be reported by the preload's signal
+// handler rather than terminating silently.
 
 #include <climits>
 #include <cstdio>

--- a/tests/record/test_crash_handling.cpp
+++ b/tests/record/test_crash_handling.cpp
@@ -1,0 +1,60 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.mneme" && mkdir -p "%t.$$.mneme"
+// RUN: env MNEME_MAX_RECORDINGS=1 LD_PRELOAD=MNEME_PRELOAD_LIB MNEME_LOG_LEVEL=debug MNEME_PAGE_SIZE=%PG MNEME_DATA_DIR="%t.$$.mneme" %build/test_crash_handling%ext > %t.out 2>&1 || true
+// RUN: %FILECHECK %s --check-prefixes=CHECK < %t.out
+// RUN: rm -rf "%t.$$.mneme"
+// clang-format on
+
+// Test that signal handler is installed and catches crashes during mneme recording
+// This test verifies the functionality added in commit c3967ac
+
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "mneme/DeviceTraits.hpp"
+using namespace mneme;
+
+#ifdef MNEME_ENABLE_HIP
+using MnemeDeviceRT = DeviceTraits<DeviceVendors::HIP>;
+#elif defined(MNEME_ENABLE_CUDA)
+using MnemeDeviceRT = DeviceTraits<DeviceVendors::CUDA>;
+#endif
+
+__global__ void simple_kernel() {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  // Just a simple kernel that does nothing
+  if (idx == 0) {
+    printf("Kernel executing\n");
+  }
+}
+
+int main(int argc, char** argv) {
+  // Launch a simple kernel - this will initialize the MnemeRecorderHIPPreload
+  // singleton via the preload library, which installs the crash handler
+  dim3 blockDim(32, 1, 1);
+  dim3 gridDim(1, 1, 1);
+  simple_kernel<<<gridDim, blockDim>>>();
+  auto EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceSynchronize());
+  if (EC) {
+    std::cout << "Error when running kernel " << EC.value() << std::endl;
+    return -1;
+  }
+
+  // Use fprintf to stderr and flush to ensure message appears before crash
+  fprintf(stderr, "Kernel completed successfully\n");
+  fflush(stderr);
+
+  // Now trigger a crash to test signal handler
+  // CHECK: Kernel completed successfully
+  // CHECK: === PROGRAM CRASHED (see core dump) ===
+
+  // Trigger segmentation fault
+  int* null_ptr = nullptr;
+  *null_ptr = 42; // This will cause SIGSEGV, which should be caught by signal handler
+
+  // Should never reach here
+  fprintf(stderr, "ERROR: Should not reach this line\n");
+  return 0;
+}


### PR DESCRIPTION
Register handlers for common signals to detect program crashes during
record. Previously, if there was an error during the recorded program, Mneme would just exit without any indication, which can be confusing from the user perspective.

HIP only for now but can add CUDA support if we think this is a good
idea.

----

this is failing on Matrix due to lack of CUDA support but can fix this later