### PR TITLE
Allow incremental writing of kernel record JSON files

### DIFF
--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -168,6 +168,18 @@ inline bool computeRecordingEnabledForCurrentRank() {
   return ParsedRanks->count(DistributedRank.value_or(0)) > 0;
 }
 
+inline bool getEnvOrDefaultBool(const char *VarName, bool Default) {
+  const char *EnvValue = std::getenv(VarName);
+  if (!EnvValue)
+    return Default;
+
+  std::string Value(EnvValue);
+  std::transform(Value.begin(), Value.end(), Value.begin(),
+                 [](unsigned char C) { return std::tolower(C); });
+
+  return Value == "1" || Value == "true" || Value == "yes" || Value == "on";
+}
+
 } // namespace config_detail
 
 class Config {
@@ -185,6 +197,7 @@ public:
   const std::optional<long> PageSizeGiB;
   const LogLevel MnemeLogLevel;
   const EpilogueSnapshotType EpilogueType;
+  const bool IncrementalKernelRecords;
 
   bool isRecordingEnabledForCurrentRank() const {
     return RecordingEnabledThisRank;
@@ -228,6 +241,8 @@ private:
             "MNEME_LOG_LEVEL", LogLevel::Critical)),
         EpilogueType(config_detail::getEnvOrDefaultEpilogueSnapshotType(
             "MNEME_EPILOGUE_TYPE", EpilogueSnapshotType::Diff)),
+        IncrementalKernelRecords(config_detail::getEnvOrDefaultBool(
+            "MNEME_INCREMENTAL_KERNEL_RECORDS", false)),
         MnemeDataDir(config_detail::getEnvOrDefaultString("MNEME_DATA_DIR")),
         MnemeLogDir(config_detail::getEnvOrDefaultString("MNEME_LOG_DIR")),
         RecordingEnabledThisRank(

--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -167,19 +167,6 @@ inline bool computeRecordingEnabledForCurrentRank() {
 
   return ParsedRanks->count(DistributedRank.value_or(0)) > 0;
 }
-
-inline bool getEnvOrDefaultBool(const char *VarName, bool Default) {
-  const char *EnvValue = std::getenv(VarName);
-  if (!EnvValue)
-    return Default;
-
-  std::string Value(EnvValue);
-  std::transform(Value.begin(), Value.end(), Value.begin(),
-                 [](unsigned char C) { return std::tolower(C); });
-
-  return Value == "1" || Value == "true" || Value == "yes" || Value == "on";
-}
-
 } // namespace config_detail
 
 class Config {
@@ -197,7 +184,6 @@ public:
   const std::optional<long> PageSizeGiB;
   const LogLevel MnemeLogLevel;
   const EpilogueSnapshotType EpilogueType;
-  const bool IncrementalKernelRecords;
 
   bool isRecordingEnabledForCurrentRank() const {
     return RecordingEnabledThisRank;
@@ -241,8 +227,6 @@ private:
             "MNEME_LOG_LEVEL", LogLevel::Critical)),
         EpilogueType(config_detail::getEnvOrDefaultEpilogueSnapshotType(
             "MNEME_EPILOGUE_TYPE", EpilogueSnapshotType::Diff)),
-        IncrementalKernelRecords(config_detail::getEnvOrDefaultBool(
-            "MNEME_INCREMENTAL_KERNEL_RECORDS", false)),
         MnemeDataDir(config_detail::getEnvOrDefaultString("MNEME_DATA_DIR")),
         MnemeLogDir(config_detail::getEnvOrDefaultString("MNEME_LOG_DIR")),
         RecordingEnabledThisRank(

--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -167,6 +167,7 @@ inline bool computeRecordingEnabledForCurrentRank() {
 
   return ParsedRanks->count(DistributedRank.value_or(0)) > 0;
 }
+
 } // namespace config_detail
 
 class Config {

--- a/include/mneme/MnemeRecordingBackend.hpp
+++ b/include/mneme/MnemeRecordingBackend.hpp
@@ -180,9 +180,7 @@ public:
                func, KInfo.getName(), GridDim.x, GridDim.y, GridDim.z,
                BlockDim.x, BlockDim.y, BlockDim.z, SharedMem);
       // write kernel record incrementally after epilogue is recorded
-      if (Config::get().IncrementalKernelRecords) {
-        DB.writeKernelJSON(KInfo.getStaticHash());
-      }
+      DB.writeKernelJSON(KInfo.getStaticHash());
     }
     return ret;
   }

--- a/include/mneme/MnemeRecordingBackend.hpp
+++ b/include/mneme/MnemeRecordingBackend.hpp
@@ -179,6 +179,10 @@ public:
                "{}) SHM_SIZE:{}",
                func, KInfo.getName(), GridDim.x, GridDim.y, GridDim.z,
                BlockDim.x, BlockDim.y, BlockDim.z, SharedMem);
+      // write kernel record incrementally after epilogue is recorded
+      if (Config::get().IncrementalKernelRecords) {
+        DB.writeKernelJSON(KInfo.getStaticHash());
+      }
     }
     return ret;
   }

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -826,15 +826,38 @@ public:
   }
 
   ~RecordDatabase() {
-    for (auto &[StaticHash, Record] : KernelRecords) {
-      auto JsonFilename =
-          MnemeDirectory / (std::to_string(StaticHash) + ".json");
-      std::error_code EC;
-      auto JSONRecord = Record.toJSON(StaticHash);
-      llvm::raw_fd_ostream JsonOS(JsonFilename.string(), EC);
-      JsonOS << llvm::json::Value(std::move(JSONRecord));
-      JsonOS.close();
+    // if incremental writing is enabled, JSON files are already written
+    if (Config::get().IncrementalKernelRecords) {
+      return;
     }
+
+    for (auto &[StaticHash, Record] : KernelRecords) {
+      writeKernelJSON(StaticHash, &Record);
+    }
+  }
+
+  void writeKernelJSON(uint64_t StaticHash, KernelInstancesCollection* Record = nullptr) {
+    KernelInstancesCollection* RecordPtr = Record;
+    if (!RecordPtr) {
+      // do lookup for external caller
+      auto It = KernelRecords.find(StaticHash);
+      if (It == KernelRecords.end()) {
+        LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}", StaticHash);
+        return;
+      }
+      RecordPtr = &It->second;
+    }
+
+    auto JsonFilename = MnemeDirectory / (std::to_string(StaticHash) + ".json");
+    std::error_code EC;
+    auto JSONRecord = RecordPtr->toJSON(StaticHash);
+    llvm::raw_fd_ostream JsonOS(JsonFilename.string(), EC);
+    if (EC) {
+      LOG_WARN("Failed to write JSON for kernel {}: {}", StaticHash, EC.message());
+      return;
+    }
+    JsonOS << llvm::json::Value(std::move(JSONRecord));
+    JsonOS.close();
   }
 
   bool shouldRecord(const std::string &KernelName) const {

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -839,12 +839,17 @@ public:
     std::error_code EC;
     llvm::raw_fd_ostream JsonOS(JsonFilename.string(), EC);
     if (EC) {
-      LOG_WARN("Failed to write JSON for kernel {}: {}", StaticHash, EC.message());
+      LOG_WARN("Failed to open JSON file for kernel {}: {}", StaticHash, EC.message());
       return;
     }
 
     JsonOS << llvm::json::Value(std::move(JSONRecord));
     JsonOS.close();
+    if (JsonOS.has_error()) {
+      LOG_WARN("Failed to write JSON for kernel {}: {}", StaticHash,
+               JsonOS.error().message());
+      return;
+    }
   }
 
   bool shouldRecord(const std::string &KernelName) const {

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -825,37 +825,24 @@ public:
     EpilogueType = Conf.EpilogueType;
   }
 
-  ~RecordDatabase() {
-    // if incremental writing is enabled, JSON files are already written
-    if (Config::get().IncrementalKernelRecords) {
+  void writeKernelJSON(uint64_t StaticHash) {
+    auto It = KernelRecords.find(StaticHash);
+    if (It == KernelRecords.end()) {
+      LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}", StaticHash);
       return;
     }
-
-    for (auto &[StaticHash, Record] : KernelRecords) {
-      writeKernelJSON(StaticHash, &Record);
-    }
-  }
-
-  void writeKernelJSON(uint64_t StaticHash, KernelInstancesCollection* Record = nullptr) {
-    KernelInstancesCollection* RecordPtr = Record;
-    if (!RecordPtr) {
-      // do lookup for external caller
-      auto It = KernelRecords.find(StaticHash);
-      if (It == KernelRecords.end()) {
-        LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}", StaticHash);
-        return;
-      }
-      RecordPtr = &It->second;
-    }
+    auto* RecordPtr = &It->second;
 
     auto JsonFilename = MnemeDirectory / (std::to_string(StaticHash) + ".json");
-    std::error_code EC;
     auto JSONRecord = RecordPtr->toJSON(StaticHash);
+
+    std::error_code EC;
     llvm::raw_fd_ostream JsonOS(JsonFilename.string(), EC);
     if (EC) {
       LOG_WARN("Failed to write JSON for kernel {}: {}", StaticHash, EC.message());
       return;
     }
+
     JsonOS << llvm::json::Value(std::move(JSONRecord));
     JsonOS.close();
   }


### PR DESCRIPTION
Adds a config option to allow a user to have their kernel JSON files dump immediately after the epilogue is written.

This can be helpful in a couple cases:
- the application takes a while to run and you don't want to wait until it's done to use the record DB
- the app/Mneme is crashing and the destructor writing the JSON files isn't being called