### PR TITLE
add hard limit on number of startup crashes

### DIFF
--- a/python/mneme/async_executor.py
+++ b/python/mneme/async_executor.py
@@ -7,7 +7,7 @@ from multiprocessing import Process
 from multiprocessing import Queue as ProcessQueue
 from queue import Queue as ThreadQueue
 from threading import Event as ThreadEvent
-from typing import Dict
+from typing import Callable, Dict, Optional
 
 from mneme.futures import EvalFuture
 from mneme.mneme_logging import logger
@@ -88,6 +88,10 @@ class TuneWorkerHandle:
         iterations: int,
         results_db_dir: str,
         warmup: int = 2,
+        max_startup_failures: int = 3,
+        on_startup_failure_limit: Optional[
+            Callable[["TuneWorkerHandle", str], None]
+        ] = None,
     ):
         """
         Construct a worker handle and start the worker process + monitor thread.
@@ -111,6 +115,9 @@ class TuneWorkerHandle:
             Directory where the worker writes logs and optional artifacts.
         warmup : int
             Number of warmup iterations executed before measured iterations.
+        max_startup_failures : int
+            Maximum number of consecutive worker exits before readiness before this
+            handle stops respawning the worker.
 
         Notes
         -----
@@ -133,6 +140,9 @@ class TuneWorkerHandle:
         self.iterations = iterations
         self.results_db_dir = results_db_dir
         self.warmup = warmup
+        self.max_startup_failures = max_startup_failures
+        self._startup_failures = 0
+        self._on_startup_failure_limit = on_startup_failure_limit
 
         self._state = None  # ProcessEvent
         self._process = None  # Process
@@ -183,6 +193,19 @@ class TuneWorkerHandle:
         )
         self._process.start()
         self._action = self.StateMachine.SUBMIT
+
+    def _startup_failure_error(self):
+        return (
+            f"Worker failed to start after {self._startup_failures} attempts "
+            f"on device {self.device_id}"
+        )
+
+    def _disable_after_startup_failures(self):
+        error = self._startup_failure_error()
+        logger.error(error)
+        self._process.join()
+        if self._on_startup_failure_limit is not None:
+            self._on_startup_failure_limit(self, error)
 
     # ------------------------------------------------------------
     # Result handling
@@ -296,7 +319,12 @@ class TuneWorkerHandle:
         while not self._shutdown_event.is_set():
             if not self._process.is_alive():
                 # Crash recovery
-                if self.current is not None:
+                if not self._state.is_set():
+                    self._startup_failures += 1
+                    if self._startup_failures >= self.max_startup_failures:
+                        self._disable_after_startup_failures()
+                        return
+                elif self.current is not None:
                     # TODO: At some point we need to have more descrptive messages on the crash, it is not always a seg fault, somethimes it is LLVM related and we should know.
                     self.current.set_error(
                         f"Worker crashed (exit code: {self._process.exitcode}) running on device {self.device_id}"
@@ -313,6 +341,8 @@ class TuneWorkerHandle:
                 # That should simplify the logic.
                 time.sleep(0.5)
                 continue
+
+            self._startup_failures = 0
 
             if self._action == self.StateMachine.SUBMIT:
                 self._submit()
@@ -370,6 +400,7 @@ class AsyncReplayExecutor:
         results_db_dir: str,
         num_workers: int,
         warmup: int = 2,
+        max_startup_failures: int = 3,
     ):
         """
         Construct an asynchronous executor with a fixed-size worker pool.
@@ -388,6 +419,9 @@ class AsyncReplayExecutor:
             Number of worker processes to launch.
         warmup : int
             Number of warmup iterations each worker executes before measured iterations.
+        max_startup_failures : int
+            Maximum number of consecutive pre-readiness startup failures allowed per
+            worker before that worker stops respawning.
         """
         self.global_q = ThreadQueue()
         self._futures: Dict[int, EvalFuture] = {}
@@ -395,20 +429,43 @@ class AsyncReplayExecutor:
         self._lock = threading.Lock()
         self.iterations = iterations
         self.warmup = warmup
+        self.max_startup_failures = max_startup_failures
+        self._num_workers = num_workers
+        self._failed_workers = set()
+        self._broken_error = None
 
-        self.workers = [
-            TuneWorkerHandle(
-                i,
-                self.global_q,
-                record_db,
-                record_id,
-                i,
-                iterations,
-                results_db_dir,
-                warmup=warmup,
+        self.workers = []
+        for i in range(num_workers):
+            self.workers.append(
+                TuneWorkerHandle(
+                    i,
+                    self.global_q,
+                    record_db,
+                    record_id,
+                    i,
+                    iterations,
+                    results_db_dir,
+                    warmup=warmup,
+                    max_startup_failures=max_startup_failures,
+                    on_startup_failure_limit=self._handle_startup_failure_limit,
+                )
             )
-            for i in range(num_workers)
-        ]
+
+    def _handle_startup_failure_limit(self, worker: TuneWorkerHandle, error: str):
+        with self._lock:
+            self._failed_workers.add(worker.idx)
+            if len(self._failed_workers) < self._num_workers:
+                return
+            self._broken_error = error
+
+        self._fail_pending_futures(error)
+
+    def _fail_pending_futures(self, error: str):
+        while True:
+            future = pop(self.global_q, timeout=0)
+            if future is None:
+                return
+            future.set_error(error)
 
     # ------------------------------------------------------------------
     # Submit new job (non-blocking)
@@ -434,11 +491,13 @@ class AsyncReplayExecutor:
         with self._lock:
             job_id = self._next_id
             self._next_id += 1
-
-        logger.debug(f"[{self.__class__.__name__}] Submitting job {job_id}")
-        future = EvalFuture(job_id, config)
-        self._futures[job_id] = future
-        self.global_q.put(future)
+            logger.debug(f"[{self.__class__.__name__}] Submitting job {job_id}")
+            future = EvalFuture(job_id, config)
+            self._futures[job_id] = future
+            if self._broken_error is not None:
+                future.set_error(self._broken_error)
+                return future
+            self.global_q.put(future)
         return future
 
     def shutdown(self):

--- a/python/tests/test_async_executor.py
+++ b/python/tests/test_async_executor.py
@@ -47,6 +47,12 @@ class DummyProcess:
         self._alive = False
 
 
+class DeadProcess(DummyProcess):
+    def __init__(self):
+        super().__init__()
+        self._alive = False
+
+
 class DummyEvent:
     def __init__(self):
         self._set = False
@@ -194,6 +200,152 @@ def test_worker_crash_marks_future_failed(handle):
     assert out.failed is True
     assert out.executed is False
     assert "Worker crashed" in out.error
+
+
+def test_worker_crash_branch_marks_future_failed_and_respawns(handle):
+    future = EvalFuture(1, ExperimentConfiguration())
+    handle.current = future
+    handle._state.set()
+    handle._process._alive = False
+    handle._process.exitcode = 42
+
+    def stop_after_respawn():
+        handle._shutdown_event.set()
+
+    handle._spawn_process = stop_after_respawn
+
+    handle._shadow_process_loop()
+
+    out = future.result(timeout=0.01)
+    assert out.failed is True
+    assert out.executed is False
+    assert "Worker crashed" in out.error
+    assert handle.current is None
+
+
+def test_ready_worker_resets_startup_failures_and_submits(handle):
+    future = EvalFuture(3, ExperimentConfiguration())
+    handle.global_q.put(future)
+    handle._startup_failures = 2
+    handle._state.set()
+
+    original_submit = handle._submit
+
+    def submit_once():
+        original_submit()
+        handle._process._alive = False
+        handle._shutdown_event.set()
+
+    handle._submit = submit_once
+
+    handle._shadow_process_loop()
+
+    assert handle._startup_failures == 0
+    assert handle.current is future
+    assert handle._action == handle.StateMachine.RECEIVE
+
+
+def test_shadow_loop_shutdown_sends_terminate_and_joins(handle):
+    handle._shutdown_event.set()
+    received = []
+
+    def receive_once():
+        received.append(True)
+        handle._process._alive = False
+
+    handle._try_receive = receive_once
+
+    handle._shadow_process_loop()
+
+    assert handle._ipc_write_q.get_nowait()["payload"] == "terminate"
+    assert received == [True]
+    assert handle._process.is_alive() is False
+
+
+def test_tuneworker_handle_join_signals_thread(handle):
+    handle.join()
+
+    assert handle._shutdown_event.is_set()
+
+
+def test_startup_failures_stop_respawning_after_limit(monkeypatch):
+    import mneme.async_executor as mod
+
+    monkeypatch.setattr(mod.threading, "Thread", NoopThread, raising=True)
+    monkeypatch.setattr(mod, "Process", lambda *a, **k: DeadProcess())
+    monkeypatch.setattr(mod, "ProcessEvent", DummyEvent)
+    monkeypatch.setattr(mod, "ProcessQueue", DummyQueue)
+
+    failures = []
+    h = mod.TuneWorkerHandle(
+        idx=0,
+        global_q=queue.Queue(),
+        record_db="db",
+        record_id="rid",
+        device_id=0,
+        iterations=3,
+        results_db_dir="/tmp",
+        max_startup_failures=3,
+        on_startup_failure_limit=lambda worker, error: failures.append(
+            (worker.idx, error)
+        ),
+    )
+
+    h._shadow_process_loop()
+
+    assert h._startup_failures == 3
+    assert failures
+    assert failures[0][0] == 0
+    assert "failed to start after 3 attempts" in failures[0][1]
+
+
+def test_executor_does_not_fail_pending_work_until_all_workers_fail(monkeypatch):
+    import mneme.async_executor as mod
+
+    monkeypatch.setattr(mod.threading, "Thread", NoopThread, raising=True)
+    monkeypatch.setattr(mod, "Process", lambda *a, **k: DeadProcess())
+    monkeypatch.setattr(mod, "ProcessEvent", DummyEvent)
+    monkeypatch.setattr(mod, "ProcessQueue", DummyQueue)
+
+    exe = mod.AsyncReplayExecutor(
+        record_db="db",
+        record_id="rid",
+        iterations=3,
+        results_db_dir="/tmp",
+        num_workers=2,
+        max_startup_failures=3,
+    )
+    future = exe.submit(ExperimentConfiguration())
+
+    exe.workers[0]._shadow_process_loop()
+    assert future.done() is False
+
+    exe.workers[1]._shadow_process_loop()
+    out = future.result(timeout=0.01)
+
+    assert out.failed is True
+    assert out.executed is False
+    assert "failed to start after 3 attempts" in out.error
+
+
+def test_submit_after_executor_broken_returns_failed_future(monkeypatch):
+    monkeypatch.setattr("mneme.async_executor.TuneWorkerHandle", lambda *a, **k: None)
+
+    exe = AsyncReplayExecutor(
+        record_db="db",
+        record_id="rid",
+        iterations=3,
+        results_db_dir="/tmp",
+        num_workers=0,
+    )
+    exe._broken_error = "all workers failed to start"
+
+    future = exe.submit(ExperimentConfiguration())
+    out = future.result(timeout=0.01)
+
+    assert out.failed is True
+    assert out.executed is False
+    assert out.error == "all workers failed to start"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #179 

There's a bug in the AsyncReplayExecutor that occurs when a TuneWorker crashes on startup. The [crash detection in the TuneWorker process loop](https://github.com/Olympus-HPC/Mneme/blob/develop/python/mneme/async_executor.py#L297-L308) only handles the crash if `current` is set, which is not the case for startup/initialization failures. So startup failures, like missing rocm symbols, just get restarted in an infinite loop.

This PR adds a counter to keep track of the number of consecutive startup crashes. It stops the outer worker loop if there are more than 3 consecutive startup crashes. 3 is configurable from the constructor.

Invalid kernel configs, segfaults, etc. are not startup crashes, so this shouldn't affect normal behavior where many kernels might crash during tuning. This only catches startup issues. But let me know if I'm missing an edge case here.