### PR TITLE
Add "best" epilogue format option

### DIFF
--- a/docs/usage/artifacts.md
+++ b/docs/usage/artifacts.md
@@ -122,6 +122,12 @@ recording with:
 mneme record --epilogue-format bytes -- <application> [args...]
 ```
 
+Use `best` to have Mneme store whichever concrete epilogue format is smaller for each recorded kernel instance:
+
+```bash
+mneme record --epilogue-format best -- <application> [args...]
+```
+
 Diff epilogues contain descriptors for the recorded globals and memory
 regions plus the changed byte ranges needed to reconstruct the
 post-kernel state. Using the diff format can save significant amounts

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -48,7 +48,7 @@ artifact.
 | `-rdb`, `--record-db-dir`               | Path to a **existing** directory where recorded artifacts (metadata, LLVM IR, and device memory snapshots) will be stored |
 | `-vass`, `--virtual-address-space-size` | Size (in **GB**) of the virtual address space allocated by Mneme for recording                                            |
 | `-mr`, `--per-kernel-max-recordings`    | Maximum number of times the same GPU kernel may be recorded with different dynamic hashes                                 |
-| `--epilogue-format`                     | Store epilogue snapshots as `diff` or `bytes`; defaults to `diff`                                                        |
+| `--epilogue-format`                     | Store epilogue snapshots as `diff`, `bytes`, or `best`; defaults to `diff`                                                        |
 | `-rr`, `--record-ranks`                 | Restrict recording to a comma-separated set of MPI ranks (e.g. `0`, `0,1,3`) or `all` for every rank. See *Multi-rank recording* below. |
 | `-h`, `--help`                          | Show help message and exit                                                                                                |
 

--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -20,7 +20,7 @@
 namespace mneme {
 
 enum class LogLevel { Trace, Debug, Info, Warn, Error, Critical, Off };
-enum class EpilogueSnapshotType { Bytes, Diff };
+enum class EpilogueSnapshotType { Bytes, Diff, Best };
 
 namespace config_detail {
 
@@ -101,8 +101,9 @@ inline LogLevel getEnvOrDefaultLogLevel(const char *VarName, LogLevel Default) {
   return LogLevel::Info;
 }
 
-inline EpilogueSnapshotType getEnvOrDefaultEpilogueSnapshotType(
-    const char *VarName, EpilogueSnapshotType Default) {
+inline EpilogueSnapshotType
+getEnvOrDefaultEpilogueSnapshotType(const char *VarName,
+                                    EpilogueSnapshotType Default) {
   auto EnvValue = getEnvOrDefaultString(VarName);
   if (!EnvValue)
     return Default;
@@ -111,9 +112,11 @@ inline EpilogueSnapshotType getEnvOrDefaultEpilogueSnapshotType(
     return EpilogueSnapshotType::Bytes;
   if (*EnvValue == "diff")
     return EpilogueSnapshotType::Diff;
+  if (*EnvValue == "best")
+    return EpilogueSnapshotType::Best;
 
   throw std::runtime_error("Invalid MNEME_EPILOGUE_TYPE value '" + *EnvValue +
-                           "'. Expected 'bytes' or 'diff'.");
+                           "'. Expected 'bytes', 'diff', or 'best'.");
 }
 
 inline bool defaultRecordingPolicy(const std::optional<int> &DistributedRank) {

--- a/include/mneme/MnemeConfig.hpp
+++ b/include/mneme/MnemeConfig.hpp
@@ -101,9 +101,8 @@ inline LogLevel getEnvOrDefaultLogLevel(const char *VarName, LogLevel Default) {
   return LogLevel::Info;
 }
 
-inline EpilogueSnapshotType
-getEnvOrDefaultEpilogueSnapshotType(const char *VarName,
-                                    EpilogueSnapshotType Default) {
+inline EpilogueSnapshotType getEnvOrDefaultEpilogueSnapshotType(
+    const char *VarName, EpilogueSnapshotType Default) {
   auto EnvValue = getEnvOrDefaultString(VarName);
   if (!EnvValue)
     return Default;

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -23,6 +23,7 @@
 #include <llvm/IR/Module.h>
 #include <string>
 #include <sys/types.h>
+#include <type_traits>
 
 #include "mneme/DeviceTraits.hpp"
 #include "mneme/MnemeConfig.hpp"
@@ -132,6 +133,15 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
   static constexpr size_t DiffMagicSize = sizeof(DiffMagic) - 1;
   static constexpr size_t DiffChunkSize = 1 << 20;
 
+  class CountingRawOStream : public llvm::raw_ostream {
+    uint64_t Pos = 0;
+
+    void write_impl(const char *, size_t Size) override { Pos += Size; }
+    uint64_t current_pos() const override { return Pos; }
+
+  public:
+    uint64_t bytesWritten() const { return Pos; }
+  };
 
   static bool isDiffBuffer(llvm::StringRef Buffer) {
     return Buffer.size() >= DiffMagicSize &&
@@ -157,7 +167,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       LOG_FATAL("Cannot diff buffers with different sizes");
 
     // Count the number of contiguous ranges that have changed between Base and
-    // Current. We want to write out the number of ranges so that the reader 
+    // Current. We want to write out the number of ranges so that the reader
     // can know how many ranges to read.
     size_t Count = 0;
     bool InRange = false;
@@ -183,7 +193,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     if (!UpdateBase.empty() && UpdateBase.size() != Base.size())
       LOG_FATAL("Cannot update diff base with mismatched buffer size");
 
-    // Write out the contiguous ranges that have changed between Base 
+    // Write out the contiguous ranges that have changed between Base
     // and Current.
     size_t Count = 0;
     size_t I = 0;
@@ -209,8 +219,10 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     return Count;
   }
 
-  static void writeCountAndWriteChangedRanges(
-      llvm::raw_ostream &OS, MnemeMemoryBlob<VendorTypes> &Blob) {
+  static void
+  writeCountAndWriteChangedRanges(llvm::raw_ostream &OS,
+                                  MnemeMemoryBlob<VendorTypes> &Blob,
+                                  bool UpdateBaseData = true) {
     auto Size = Blob.getSize();
 
     // early exit
@@ -240,9 +252,14 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
 
       llvm::ArrayRef<uint8_t> ChunkBase(Base + Offset, ChunkSize);
       llvm::ArrayRef<uint8_t> ChunkCurrent(Scratch.get(), ChunkSize);
-      llvm::MutableArrayRef<uint8_t> UpdateBase(Base + Offset, ChunkSize);
-      NumRanges += writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset,
-                                       UpdateBase);
+      if (UpdateBaseData) {
+        llvm::MutableArrayRef<uint8_t> UpdateBase(Base + Offset, ChunkSize);
+        NumRanges += writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset,
+                                        UpdateBase);
+      } else {
+        NumRanges +=
+            writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset);
+      }
     }
 
     util::writeScalar(OS, NumRanges);
@@ -354,16 +371,52 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       if (Blob.getActualSize() != ActualSize || Blob.getSize() != Size)
         LOG_FATAL("Mneme diff memory blob size mismatch");
       Blob.setMetadata(MD);
-      applyDiffRanges(
-          CurrentPtr,
-          llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
-                                         Blob.getSize()),
-          NumRanges);
+      applyDiffRanges(CurrentPtr,
+                      llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
+                                                     Blob.getSize()),
+                      NumRanges);
     }
   }
 
+  static size_t getSerializedMetadataSize(const Metadata &MD) {
+    return sizeof(std::underlying_type_t<BuiltinDType>) + sizeof(double) +
+           sizeof(ThresholdKind) + sizeof(Norm) + sizeof(size_t) +
+           (MD.tag ? MD.tag->size() : 0);
+  }
+
+  static size_t computeMnemeBytesSnapshotSize(
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
+      const llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
+      llvm::ArrayRef<size_t> KernelArgSizes) {
+    size_t Size = sizeof(size_t);
+    for (const auto &[VarName, GV] : GlobalVars) {
+      Size += sizeof(size_t);
+      Size += VarName.size();
+      Size += sizeof(GV.VarSize);
+      Size += sizeof(GV.DevAddr);
+      Size += GV.VarSize;
+    }
+
+    Size += sizeof(size_t);
+    for (const auto &[Ptr, Blob] : DeviceMemory) {
+      Size += sizeof(size_t);
+      Size += sizeof(size_t);
+      Size += sizeof(void *);
+      Size += Blob.getSize();
+      Size += getSerializedMetadataSize(Blob.getMetadata());
+    }
+
+    Size += sizeof(size_t);
+    for (size_t ArgSize : KernelArgSizes) {
+      Size += sizeof(size_t);
+      Size += ArgSize;
+    }
+    return Size;
+  }
+
 public:
-  using GlobalSnapshotData = std::unordered_map<std::string, std::vector<uint8_t>>;
+  using GlobalSnapshotData =
+      std::unordered_map<std::string, std::vector<uint8_t>>;
 
   static std::pair<std::string, ReplayGlobalVar>
   fromBuffer(const char *&Buffer) {
@@ -458,22 +511,11 @@ public:
     return Filename.filename();
   }
 
-  std::filesystem::path static takeMnemeDiffSnapshot(
+  static void writeMnemeDiffSnapshot(
+      llvm::raw_ostream &OutBC,
       const proteus::runtime::GlobalMetadataMap &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      std::filesystem::path &Filename,
-      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
-    LOG_DEBUG("Storing mneme diff snapshot: {}", Filename.string());
-    std::error_code EC;
-    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
-    if (DEC)
-      LOG_FATAL("Synchronizing stream failed before diff snapshot");
-
-    llvm::raw_fd_ostream OutBC(Filename.string(), EC);
-    if (EC)
-      LOG_FATAL("Cannot write Mneme diff snapshot: " + EC.message());
-
+      const GlobalSnapshotData &PrologueGlobals, bool UpdateBaseData) {
     util::writeBytes(OutBC, llvm::StringRef(DiffMagic, DiffMagicSize));
 
     size_t TotalGlobals = GlobalVars.size();
@@ -513,10 +555,63 @@ public:
       auto MD = Blob.getMetadata();
       mneme::metadata::serialize(OutBC, MD);
 
-      writeCountAndWriteChangedRanges(OutBC, Blob);
+      writeCountAndWriteChangedRanges(OutBC, Blob, UpdateBaseData);
     }
+  }
 
+  static size_t measureMnemeDiffSnapshotSize(
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
+      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
+      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
+    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
+    if (DEC)
+      LOG_FATAL("Synchronizing stream failed before diff snapshot");
+
+    CountingRawOStream Counter;
+    writeMnemeDiffSnapshot(Counter, GlobalVars, DeviceMemory, PrologueGlobals,
+                           false);
+    return Counter.bytesWritten();
+  }
+
+  std::filesystem::path static takeMnemeDiffSnapshot(
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
+      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
+      std::filesystem::path &Filename,
+      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
+    LOG_DEBUG("Storing mneme diff snapshot: {}", Filename.string());
+    std::error_code EC;
+    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
+    if (DEC)
+      LOG_FATAL("Synchronizing stream failed before diff snapshot");
+
+    llvm::raw_fd_ostream OutBC(Filename.string(), EC);
+    if (EC)
+      LOG_FATAL("Cannot write Mneme diff snapshot: " + EC.message());
+
+    writeMnemeDiffSnapshot(OutBC, GlobalVars, DeviceMemory, PrologueGlobals,
+                           true);
     return Filename.filename();
+  }
+
+  std::filesystem::path static takeBestMnemeSnapshot(
+      const proteus::runtime::GlobalMetadataMap &GlobalVars,
+      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
+      std::filesystem::path &Filename,
+      llvm::SmallVector<size_t> &KernelArgSizes, void **Args,
+      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
+    size_t BytesSize =
+        computeMnemeBytesSnapshotSize(GlobalVars, DeviceMemory, KernelArgSizes);
+    size_t DiffSize = measureMnemeDiffSnapshotSize(GlobalVars, DeviceMemory,
+                                                   PrologueGlobals, Stream);
+
+    if (DiffSize <= BytesSize)
+      return takeMnemeDiffSnapshot(GlobalVars, DeviceMemory, Filename,
+                                   PrologueGlobals, Stream);
+
+    return takeMnemeBytesSnapshot(GlobalVars, DeviceMemory, Filename,
+                                  KernelArgSizes, Args, Stream);
   }
 
   // Opens Filename and returns it as the concrete on-disk format detected from
@@ -547,8 +642,9 @@ public:
 };
 
 template <DeviceVendors VendorTypes>
-Snapshot<VendorTypes> BytesSnapshotFile<VendorTypes>::reconstruct(
-    const std::string &KernelName, const std::string &) const {
+Snapshot<VendorTypes>
+BytesSnapshotFile<VendorTypes>::reconstruct(const std::string &KernelName,
+                                            const std::string &) const {
   Snapshot<VendorTypes> Snap;
   // KernelInfo's constructor takes a non-const std::string &, so name it with a
   // mutable local.
@@ -568,8 +664,8 @@ Snapshot<VendorTypes> DiffSnapshotFile<VendorTypes>::reconstruct(
 
   // A diff stores only changed ranges, so reconstruct the full base prologue
   // first and then overlay the diff onto it.
-  Snapshot<VendorTypes> Snap =
-      MnemeSnapshot<VendorTypes>::readBytesSnapshot(KernelName, BasePrologueFile);
+  Snapshot<VendorTypes> Snap = MnemeSnapshot<VendorTypes>::readBytesSnapshot(
+      KernelName, BasePrologueFile);
   MnemeSnapshot<VendorTypes>::applyDiffMnemeSnapShot(
       this->Filename, Snap.GlobalVars, Snap.DeviceMemory, this->Buffer.get());
   return Snap;
@@ -622,7 +718,7 @@ class KernelInstancesCollection {
 
 private:
   // Parse Proteus's serialized bitcode in a Mneme-owned LLVMContext and
-  // extract per-argument metadata. Operating on a Mneme-owned Module 
+  // extract per-argument metadata. Operating on a Mneme-owned Module
   // keeps Mneme's LLVM runtime from touching any
   // Proteus-owned LLVM C++ object across the DSO boundary.
   void extractArgInfoFromBitcode(llvm::StringRef Bitcode) {
@@ -701,8 +797,8 @@ public:
       LOG_FATAL("Empty bitcode for kernel " + KName);
 
     extractArgInfoFromBitcode(Bitcode);
-    ModuleFiles.emplace_back(StoreModuleBytes(
-        Bitcode, MnemeDirectory, KInfo.getStaticHash()));
+    ModuleFiles.emplace_back(
+        StoreModuleBytes(Bitcode, MnemeDirectory, KInfo.getStaticHash()));
   }
 
   llvm::stable_hash computeHash(dim3 &GridDim, dim3 &BlockDim,
@@ -781,16 +877,23 @@ public:
               switch (EpilogueType) {
               case EpilogueSnapshotType::Bytes:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeBytesSnapshot(
-                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
-                        Args, Stream)
+                    SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory,
+                                                      Filename, KernelArgSizes,
+                                                      Args, Stream)
                         .string();
                 break;
               case EpilogueSnapshotType::Diff:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeDiffSnapshot(
-                        GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
-                        Stream)
+                    SnapshotT::takeMnemeDiffSnapshot(GlobalVars, DeviceMemory,
+                                                     Filename, *PrologueGlobals,
+                                                     Stream)
+                        .string();
+                break;
+              case EpilogueSnapshotType::Best:
+                Instances[DynamicHash].EpilogueFn =
+                    SnapshotT::takeBestMnemeSnapshot(
+                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
+                        Args, *PrologueGlobals, Stream)
                         .string();
                 break;
               }
@@ -828,10 +931,11 @@ public:
   void writeKernelJSON(uint64_t StaticHash) {
     auto It = KernelRecords.find(StaticHash);
     if (It == KernelRecords.end()) {
-      LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}", StaticHash);
+      LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}",
+               StaticHash);
       return;
     }
-    auto* RecordPtr = &It->second;
+    auto *RecordPtr = &It->second;
 
     auto JsonFilename = MnemeDirectory / (std::to_string(StaticHash) + ".json");
     auto JSONRecord = RecordPtr->toJSON(StaticHash);
@@ -839,7 +943,8 @@ public:
     std::error_code EC;
     llvm::raw_fd_ostream JsonOS(JsonFilename.string(), EC);
     if (EC) {
-      LOG_WARN("Failed to open JSON file for kernel {}: {}", StaticHash, EC.message());
+      LOG_WARN("Failed to open JSON file for kernel {}: {}", StaticHash,
+               EC.message());
       return;
     }
 

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -168,7 +168,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       LOG_FATAL("Cannot diff buffers with different sizes");
 
     // Count the number of contiguous ranges that have changed between Base and
-    // Current. We want to write out the number of ranges so that the reader
+    // Current. We want to write out the number of ranges so that the reader 
     // can know how many ranges to read.
     size_t Count = 0;
     bool InRange = false;
@@ -194,7 +194,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     if (!UpdateBase.empty() && UpdateBase.size() != Base.size())
       LOG_FATAL("Cannot update diff base with mismatched buffer size");
 
-    // Write out the contiguous ranges that have changed between Base
+    // Write out the contiguous ranges that have changed between Base 
     // and Current.
     size_t Count = 0;
     size_t I = 0;
@@ -220,10 +220,9 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     return Count;
   }
 
-  static void
-  writeCountAndWriteChangedRanges(llvm::raw_ostream &OS,
-                                  MnemeMemoryBlob<VendorTypes> &Blob,
-                                  bool UpdateBaseData = true) {
+  static void writeCountAndWriteChangedRanges(
+      llvm::raw_ostream &OS, MnemeMemoryBlob<VendorTypes> &Blob,
+      bool UpdateBaseData = true) {
     auto Size = Blob.getSize();
 
     // early exit
@@ -372,10 +371,11 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
       if (Blob.getActualSize() != ActualSize || Blob.getSize() != Size)
         LOG_FATAL("Mneme diff memory blob size mismatch");
       Blob.setMetadata(MD);
-      applyDiffRanges(CurrentPtr,
-                      llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
-                                                     Blob.getSize()),
-                      NumRanges);
+      applyDiffRanges(
+          CurrentPtr,
+          llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
+                                         Blob.getSize()),
+          NumRanges);
     }
   }
 
@@ -416,8 +416,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
   }
 
 public:
-  using GlobalSnapshotData =
-      std::unordered_map<std::string, std::vector<uint8_t>>;
+  using GlobalSnapshotData = std::unordered_map<std::string, std::vector<uint8_t>>;
 
   static std::pair<std::string, ReplayGlobalVar>
   fromBuffer(const char *&Buffer) {
@@ -643,9 +642,8 @@ public:
 };
 
 template <DeviceVendors VendorTypes>
-Snapshot<VendorTypes>
-BytesSnapshotFile<VendorTypes>::reconstruct(const std::string &KernelName,
-                                            const std::string &) const {
+Snapshot<VendorTypes> BytesSnapshotFile<VendorTypes>::reconstruct(
+    const std::string &KernelName, const std::string &) const {
   Snapshot<VendorTypes> Snap;
   // KernelInfo's constructor takes a non-const std::string &, so name it with a
   // mutable local.
@@ -665,8 +663,8 @@ Snapshot<VendorTypes> DiffSnapshotFile<VendorTypes>::reconstruct(
 
   // A diff stores only changed ranges, so reconstruct the full base prologue
   // first and then overlay the diff onto it.
-  Snapshot<VendorTypes> Snap = MnemeSnapshot<VendorTypes>::readBytesSnapshot(
-      KernelName, BasePrologueFile);
+  Snapshot<VendorTypes> Snap =
+      MnemeSnapshot<VendorTypes>::readBytesSnapshot(KernelName, BasePrologueFile);
   MnemeSnapshot<VendorTypes>::applyDiffMnemeSnapShot(
       this->Filename, Snap.GlobalVars, Snap.DeviceMemory, this->Buffer.get());
   return Snap;
@@ -719,7 +717,7 @@ class KernelInstancesCollection {
 
 private:
   // Parse Proteus's serialized bitcode in a Mneme-owned LLVMContext and
-  // extract per-argument metadata. Operating on a Mneme-owned Module
+  // extract per-argument metadata. Operating on a Mneme-owned Module 
   // keeps Mneme's LLVM runtime from touching any
   // Proteus-owned LLVM C++ object across the DSO boundary.
   void extractArgInfoFromBitcode(llvm::StringRef Bitcode) {
@@ -798,8 +796,8 @@ public:
       LOG_FATAL("Empty bitcode for kernel " + KName);
 
     extractArgInfoFromBitcode(Bitcode);
-    ModuleFiles.emplace_back(
-        StoreModuleBytes(Bitcode, MnemeDirectory, KInfo.getStaticHash()));
+    ModuleFiles.emplace_back(StoreModuleBytes(
+        Bitcode, MnemeDirectory, KInfo.getStaticHash()));
   }
 
   llvm::stable_hash computeHash(dim3 &GridDim, dim3 &BlockDim,
@@ -878,16 +876,16 @@ public:
               switch (EpilogueType) {
               case EpilogueSnapshotType::Bytes:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory,
-                                                      Filename, KernelArgSizes,
-                                                      Args, Stream)
+                    SnapshotT::takeMnemeBytesSnapshot(
+                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
+                        Args, Stream)
                         .string();
                 break;
               case EpilogueSnapshotType::Diff:
                 Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeDiffSnapshot(GlobalVars, DeviceMemory,
-                                                     Filename, *PrologueGlobals,
-                                                     Stream)
+                    SnapshotT::takeMnemeDiffSnapshot(
+                        GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
+                        Stream)
                         .string();
                 break;
               case EpilogueSnapshotType::Best:
@@ -932,11 +930,10 @@ public:
   void writeKernelJSON(uint64_t StaticHash) {
     auto It = KernelRecords.find(StaticHash);
     if (It == KernelRecords.end()) {
-      LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}",
-               StaticHash);
+      LOG_WARN("Attempted to write JSON for unrecorded kernel hash {}", StaticHash);
       return;
     }
-    auto *RecordPtr = &It->second;
+    auto* RecordPtr = &It->second;
 
     auto JsonFilename = MnemeDirectory / (std::to_string(StaticHash) + ".json");
     auto JSONRecord = RecordPtr->toJSON(StaticHash);
@@ -944,8 +941,7 @@ public:
     std::error_code EC;
     llvm::raw_fd_ostream JsonOS(JsonFilename.string(), EC);
     if (EC) {
-      LOG_WARN("Failed to open JSON file for kernel {}: {}", StaticHash,
-               EC.message());
+      LOG_WARN("Failed to open JSON file for kernel {}: {}", StaticHash, EC.message());
       return;
     }
 

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -140,7 +140,8 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     uint64_t current_pos() const override { return Pos; }
 
   public:
-    uint64_t bytesWritten() const { return Pos; }
+    CountingRawOStream() : llvm::raw_ostream(/*unbuffered=*/true) {}
+    uint64_t bytesWritten() const { return tell(); }
   };
 
   static bool isDiffBuffer(llvm::StringRef Buffer) {

--- a/python/mneme/commands.py
+++ b/python/mneme/commands.py
@@ -245,9 +245,9 @@ class Record:
         )
         parser.add_argument(
             "--epilogue-format",
-            choices=["bytes", "diff"],
+            choices=["bytes", "diff", "best"],
             default="diff",
-            help="The format to use when saving epilogue snapshots, either as full bytes or as diffs from the prologue",
+            help="The format to use when saving epilogue snapshots: full bytes, diffs from the prologue, or the smaller of the two",
         )
         parser.add_argument(
             "-rr",

--- a/python/tests/test_cli_record.py
+++ b/python/tests/test_cli_record.py
@@ -87,7 +87,10 @@ def test_record_happy_path(tmp_path, record_parser, monkeypatch):
     assert env["MNEME_LOG_LEVEL"] == "DEBUG"
 
 
-def test_record_epilogue_format_sets_env(tmp_path, record_parser, monkeypatch):
+@pytest.mark.parametrize("epilogue_format", ["bytes", "diff", "best"])
+def test_record_epilogue_format_sets_env(
+    tmp_path, record_parser, monkeypatch, epilogue_format
+):
     """--epilogue-format overrides the MNEME_EPILOGUE_TYPE runtime config."""
     record_dir = tmp_path / "records"
     record_dir.mkdir()
@@ -110,7 +113,7 @@ def test_record_epilogue_format_sets_env(tmp_path, record_parser, monkeypatch):
             "--record-db-dir",
             str(record_dir),
             "--epilogue-format",
-            "bytes",
+            epilogue_format,
             "--",
             "/usr/bin/true",
         ]
@@ -118,7 +121,7 @@ def test_record_epilogue_format_sets_env(tmp_path, record_parser, monkeypatch):
 
     Record.run(args, verbosity=None)
 
-    assert captured["env"]["MNEME_EPILOGUE_TYPE"] == "bytes"
+    assert captured["env"]["MNEME_EPILOGUE_TYPE"] == epilogue_format
 
 
 def test_record_rejects_invalid_epilogue_format(record_parser):

--- a/tests/unit_tests/Config.cpp
+++ b/tests/unit_tests/Config.cpp
@@ -141,6 +141,13 @@ int main() {
            "MNEME_EPILOGUE_TYPE should map bytes");
   }
 
+  setenv("MNEME_EPILOGUE_TYPE", "best", 1);
+  {
+    auto Conf = Config::createFromEnvironment();
+    expect(Conf.EpilogueType == EpilogueSnapshotType::Best,
+           "MNEME_EPILOGUE_TYPE should map best");
+  }
+
   setenv("MNEME_EPILOGUE_TYPE", "delta", 1);
   {
     bool Threw = false;

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -105,9 +105,9 @@ int main(int argc, char **argv) {
   std::filesystem::path SnapshotFN("./test.mneme");
 
   MnemeSnapshot<Vendor>::GlobalSnapshotData PrologueGlobals;
-  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(GVars, DeviceMemMap, SnapshotFN,
-                                                TestKernel->KernelArgSizes,
-                                                Args, 0, &PrologueGlobals);
+  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(
+      GVars, DeviceMemMap, SnapshotFN, TestKernel->KernelArgSizes, Args, 0,
+      &PrologueGlobals);
 
   auto ReadSnap =
       MnemeSnapshot<Vendor>::readBytesSnapshot(KernelName, SnapshotFN.string());
@@ -237,15 +237,15 @@ int main(int argc, char **argv) {
   GlobalData.second[3] ^= 0x9;
   GlobalData.second[4] ^= 0x13;
 
-  auto EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceCopy(BlobData.first, BlobData.second, 128,
-                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  auto EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
+      BlobData.first, BlobData.second, 128,
+      MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device blob data");
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceCopy(GlobalData.first, GlobalData.second, 128,
-                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
+      GlobalData.first, GlobalData.second, 128,
+      MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device global data");
 
@@ -417,8 +417,7 @@ int main(int argc, char **argv) {
   delete[] GlobalData.second;
   delete[] BlobData.second;
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(
-      MnemeDeviceRT::DeviceFree(GlobalData.first));
+  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceFree(GlobalData.first));
   if (EC)
     LOG_FATAL("Could not release device memory\n");
 

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
 #include <memory>
@@ -23,6 +24,13 @@ constexpr DeviceVendors Vendor = DeviceVendors::CUDA;
 using MnemeDeviceRT = DeviceTraits<DeviceVendors::CUDA>;
 using MnemeMemoryBlobDevice = MnemeMemoryBlob<DeviceVendors::CUDA>;
 #endif
+
+bool isDiffSnapshotFile(const std::filesystem::path &Path) {
+  std::ifstream In(Path, std::ios::binary);
+  std::string Magic(13, '\0');
+  In.read(Magic.data(), Magic.size());
+  return Magic == "MNEME_DIFF_V1";
+}
 
 template <typename T> void initializeRandomBuffer(T *Buffer, size_t Size) {
   // Random number generation setup
@@ -97,9 +105,9 @@ int main(int argc, char **argv) {
   std::filesystem::path SnapshotFN("./test.mneme");
 
   MnemeSnapshot<Vendor>::GlobalSnapshotData PrologueGlobals;
-  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(
-      GVars, DeviceMemMap, SnapshotFN, TestKernel->KernelArgSizes, Args, 0,
-      &PrologueGlobals);
+  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(GVars, DeviceMemMap, SnapshotFN,
+                                                TestKernel->KernelArgSizes,
+                                                Args, 0, &PrologueGlobals);
 
   auto ReadSnap =
       MnemeSnapshot<Vendor>::readBytesSnapshot(KernelName, SnapshotFN.string());
@@ -229,15 +237,15 @@ int main(int argc, char **argv) {
   GlobalData.second[3] ^= 0x9;
   GlobalData.second[4] ^= 0x13;
 
-  auto EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
-      BlobData.first, BlobData.second, 128,
-      MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  auto EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceCopy(BlobData.first, BlobData.second, 128,
+                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device blob data");
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceCopy(
-      GlobalData.first, GlobalData.second, 128,
-      MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceCopy(GlobalData.first, GlobalData.second, 128,
+                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
     LOG_FATAL("Could not update device global data");
 
@@ -319,14 +327,91 @@ int main(int argc, char **argv) {
     return 0;
   }();
 
+  auto ResetBlobBase = [&]() {
+    auto PrologueBlobIt = ReadDeviceMemMap.find((void *)BlobData.first);
+    auto HostData = std::unique_ptr<uint8_t[]>(new uint8_t[128]);
+    std::memcpy(HostData.get(), PrologueBlobIt->second.getHostData().get(),
+                128);
+    DeviceMemMap[(void *)BlobData.first].setHostData(std::move(HostData));
+  };
+
+  llvm::SmallVector<size_t> EmptyArgSizes;
+
+  ResetBlobBase();
+  std::filesystem::path SparseBestSnapshotFN("./test.best.sparse.mneme");
+  MnemeSnapshot<Vendor>::takeBestMnemeSnapshot(
+      GVars, DeviceMemMap, SparseBestSnapshotFN, EmptyArgSizes, nullptr,
+      PrologueGlobals, 0);
+  auto ValidateBestSparse = [&]() {
+    if (!isDiffSnapshotFile(SparseBestSnapshotFN)) {
+      std::cerr << "Best sparse snapshot should choose diff\n";
+      return 64;
+    }
+    auto BestSparseSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
+        KernelName, SparseBestSnapshotFN.string(), SnapshotFN.string());
+    auto It = BestSparseSnap.DeviceMemory.find((void *)BlobData.first);
+    if (It == BestSparseSnap.DeviceMemory.end() ||
+        std::memcmp(BlobData.second, It->second.getHostData().get(), 128) !=
+            0) {
+      std::cerr << "Best sparse snapshot did not reconstruct epilogue data\n";
+      return 64;
+    }
+    return 0;
+  }();
+
+  auto PrologueBlobIt = ReadDeviceMemMap.find((void *)BlobData.first);
+  auto PrologueGlobalIt = ReadGVars.find("Test");
+  auto *PrologueBlob = PrologueBlobIt->second.getHostData().get();
+  auto *PrologueGlobal =
+      static_cast<uint8_t *>(PrologueGlobalIt->second.HostAddr);
+  for (size_t I = 0; I < 128; ++I) {
+    BlobData.second[I] = PrologueBlob[I] ^ 0xff;
+    GlobalData.second[I] = PrologueGlobal[I] ^ 0xff;
+  }
+
+  EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceCopy(BlobData.first, BlobData.second, 128,
+                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  if (EC)
+    LOG_FATAL("Could not update dense device blob data");
+
+  EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceCopy(GlobalData.first, GlobalData.second, 128,
+                                MnemeDeviceRT::MemcpyHostToDeviceKind()));
+  if (EC)
+    LOG_FATAL("Could not update dense device global data");
+
+  ResetBlobBase();
+  std::filesystem::path DenseBestSnapshotFN("./test.best.dense.mneme");
+  MnemeSnapshot<Vendor>::takeBestMnemeSnapshot(
+      GVars, DeviceMemMap, DenseBestSnapshotFN, EmptyArgSizes, nullptr,
+      PrologueGlobals, 0);
+  auto ValidateBestDense = [&]() {
+    if (isDiffSnapshotFile(DenseBestSnapshotFN)) {
+      std::cerr << "Best dense snapshot should choose bytes\n";
+      return 128;
+    }
+    auto BestDenseSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
+        KernelName, DenseBestSnapshotFN.string(), SnapshotFN.string());
+    auto It = BestDenseSnap.DeviceMemory.find((void *)BlobData.first);
+    if (It == BestDenseSnap.DeviceMemory.end() ||
+        std::memcmp(BlobData.second, It->second.getHostData().get(), 128) !=
+            0) {
+      std::cerr << "Best dense snapshot did not reconstruct epilogue data\n";
+      return 128;
+    }
+    return 0;
+  }();
+
   auto Ret = ValidateGlobalMem | ValidateDeviceMem | ValidateKernelArgs |
              ValidateDiffGlobalMem | ValidateDiffDeviceMem |
-             ValidateDiffKernelArgs;
+             ValidateDiffKernelArgs | ValidateBestSparse | ValidateBestDense;
 
   delete[] GlobalData.second;
   delete[] BlobData.second;
 
-  EC = MnemeDeviceRT::DeviceErrorCheck(MnemeDeviceRT::DeviceFree(GlobalData.first));
+  EC = MnemeDeviceRT::DeviceErrorCheck(
+      MnemeDeviceRT::DeviceFree(GlobalData.first));
   if (EC)
     LOG_FATAL("Could not release device memory\n");
 

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -364,40 +364,46 @@ int main(int argc, char **argv) {
   auto *PrologueBlob = PrologueBlobIt->second.getHostData().get();
   auto *PrologueGlobal =
       static_cast<uint8_t *>(PrologueGlobalIt->second.HostAddr);
+  // Alternating changes force many one-byte diff ranges, making the bytes
+  // snapshot smaller than the diff snapshot.
   for (size_t I = 0; I < 128; ++I) {
-    BlobData.second[I] = PrologueBlob[I] ^ 0xff;
-    GlobalData.second[I] = PrologueGlobal[I] ^ 0xff;
+    BlobData.second[I] = (I % 2 == 0) ? (PrologueBlob[I] ^ 0xff)
+                                      : PrologueBlob[I];
+    GlobalData.second[I] = (I % 2 == 0) ? (PrologueGlobal[I] ^ 0xff)
+                                        : PrologueGlobal[I];
   }
 
   EC = MnemeDeviceRT::DeviceErrorCheck(
       MnemeDeviceRT::DeviceCopy(BlobData.first, BlobData.second, 128,
                                 MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
-    LOG_FATAL("Could not update dense device blob data");
+    LOG_FATAL("Could not update fragmented device blob data");
 
   EC = MnemeDeviceRT::DeviceErrorCheck(
       MnemeDeviceRT::DeviceCopy(GlobalData.first, GlobalData.second, 128,
                                 MnemeDeviceRT::MemcpyHostToDeviceKind()));
   if (EC)
-    LOG_FATAL("Could not update dense device global data");
+    LOG_FATAL("Could not update fragmented device global data");
 
   ResetBlobBase();
-  std::filesystem::path DenseBestSnapshotFN("./test.best.dense.mneme");
+  std::filesystem::path FragmentedBestSnapshotFN(
+      "./test.best.fragmented.mneme");
   MnemeSnapshot<Vendor>::takeBestMnemeSnapshot(
-      GVars, DeviceMemMap, DenseBestSnapshotFN, EmptyArgSizes, nullptr,
+      GVars, DeviceMemMap, FragmentedBestSnapshotFN, EmptyArgSizes, nullptr,
       PrologueGlobals, 0);
-  auto ValidateBestDense = [&]() {
-    if (isDiffSnapshotFile(DenseBestSnapshotFN)) {
-      std::cerr << "Best dense snapshot should choose bytes\n";
+  auto ValidateBestFragmented = [&]() {
+    if (isDiffSnapshotFile(FragmentedBestSnapshotFN)) {
+      std::cerr << "Best fragmented snapshot should choose bytes\n";
       return 128;
     }
-    auto BestDenseSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
-        KernelName, DenseBestSnapshotFN.string(), SnapshotFN.string());
-    auto It = BestDenseSnap.DeviceMemory.find((void *)BlobData.first);
-    if (It == BestDenseSnap.DeviceMemory.end() ||
+    auto BestFragmentedSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
+        KernelName, FragmentedBestSnapshotFN.string(), SnapshotFN.string());
+    auto It = BestFragmentedSnap.DeviceMemory.find((void *)BlobData.first);
+    if (It == BestFragmentedSnap.DeviceMemory.end() ||
         std::memcmp(BlobData.second, It->second.getHostData().get(), 128) !=
             0) {
-      std::cerr << "Best dense snapshot did not reconstruct epilogue data\n";
+      std::cerr
+          << "Best fragmented snapshot did not reconstruct epilogue data\n";
       return 128;
     }
     return 0;
@@ -405,7 +411,8 @@ int main(int argc, char **argv) {
 
   auto Ret = ValidateGlobalMem | ValidateDeviceMem | ValidateKernelArgs |
              ValidateDiffGlobalMem | ValidateDiffDeviceMem |
-             ValidateDiffKernelArgs | ValidateBestSparse | ValidateBestDense;
+             ValidateDiffKernelArgs | ValidateBestSparse |
+             ValidateBestFragmented;
 
   delete[] GlobalData.second;
   delete[] BlobData.second;


### PR DESCRIPTION
Adds an option for the "best" epilogue format based on disk space to address #176. I'm considering renaming this to "space-efficient" given that we could also add a replay-time-efficient "best" option.

Another consideration: right now this just makes an extra diff range pass on the CPU to compare the byte and diff epilogue sizes. This could probably be sped up with a heuristic to determine how sparse the data is. Or we could default to constructing the diff and fall back to bytes if, in the middle of the diff construction, the epilogue surpasses the size of the 'bytes' epilogue.