### PR TITLE
Allow replay to infer singleton record IDs

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -149,6 +149,10 @@ disable specialization, adjust compiler optimization levels, and
 experiment with alternative code-generation strategies.
 Replay executes the kernel using the recorded device memory state and
 verifies correctness against the original execution.
+When the database contains exactly one recorded instance,
+Mneme selects it automatically.
+Databases with multiple instances require an explicit record ID.
+Empty databases cannot be replayed.
 
 ### Arguments
 
@@ -157,12 +161,16 @@ verifies correctness against the original execution.
 | `passes` | Compilation pipeline used to compile and execute the kernel (e.g., `default<O3>`) |
 
 
-### Required Options
+### Required option
 
 | Option                      | Description                                          |
 | --------------------------- | ---------------------------------------------------- |
 | `-rdb`, `--record-database` | Path to the Mneme JSON recording database file       |
-| `-record-id`, `-rid`        | Identifier of the recorded kernel instance to replay |
+
+### Record selection
+
+Use `-record-id` or `-rid` to select a recorded kernel instance explicitly.
+The option may be omitted when the database contains exactly one instance.
 
 ### Kernel launch configuration
 When omitted, all values default to those recorded during execution.
@@ -208,7 +216,6 @@ When omitted, all values default to those recorded during execution.
 ```bash
 mneme replay \
   -rdb record-dir/15941914485064662553.json \
-  -rid 16313427880266313990 \
   "default<O3>"
 ```
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -103,10 +103,16 @@ After the execution of the example you can check the generated recorded artifact
 ### Phase 3: Replay kernel 
 
 ```bash
-mneme replay -rdb record-example-dir/15941914485064662553.json -rid 16313427880266313990 "default<O3>"
+mneme replay -rdb record-example-dir/15941914485064662553.json "default<O3>"
 ```
 
-This command will execute the kernel and **replay** the exact same execution as the recorded one. If the command completes successfully and produces a JSON file, recording worked. The output will be similar to:
+This recording contains one kernel instance,
+so Mneme selects its record ID automatically.
+The command will execute the kernel and **replay** the exact same execution
+as the recorded one.
+If the command completes successfully and produces a JSON file,
+recording worked.
+The output will be similar to:
 
 ```json
 {
@@ -160,7 +166,10 @@ This command will execute the kernel and **replay** the exact same execution as 
 ```
 
 !!! note
-    The exact names of the `-rdb` and `-rid` parameters will differ and the user should discover them. The former (`-rdb`) points to the json file under the `./record-example-dir/` and the latter (`-rid`) should take the key value of the entries under the `instances` config. The user should discover them.
+    The exact `-rdb` filename will differ.
+    It points to the JSON file under `./record-example-dir/`.
+    If that database contains multiple entries under `instances`,
+    select one explicitly with `-rid <record-id>`.
 
 !!! note
     If verified on the *Result* entry is true and executed is true, **Congratulations** you have replayed successfully a vector addition.

--- a/python/mneme/commands.py
+++ b/python/mneme/commands.py
@@ -404,8 +404,8 @@ class Replay(BaseExecutor):
             "-record-id",
             "-rid",
             dest="record_id",
-            required=True,
-            help="Kernel ID to operate on",
+            default=None,
+            help="Kernel ID to operate on; inferred when the database contains exactly one instance",
         )
 
         parser.add_argument(

--- a/python/mneme/replay_executor.py
+++ b/python/mneme/replay_executor.py
@@ -120,7 +120,7 @@ class BaseExecutor:
                 raise ValueError(
                     f"Cannot infer record ID from '{self.record_db}': expected "
                     f"exactly one recorded instance, found {num_records}. "
-                    "Specify -rid/--record-id."
+                    "Specify -rid/-record-id."
                 )
             record_id = next(iter(self.records))
         self.record_id = record_id

--- a/python/mneme/replay_executor.py
+++ b/python/mneme/replay_executor.py
@@ -34,7 +34,7 @@ TuneWorker:
 import os
 from datetime import datetime, timezone
 from multiprocessing import Event, Queue
-from typing import Tuple
+from typing import Optional, Tuple
 
 from mneme.device import (
     DeviceFunction,
@@ -61,7 +61,8 @@ class BaseExecutor:
 
     A BaseExecutor instance is bound to:
       * one recorded database file (record_db),
-      * one kernel instance inside that database (record_id),
+      * one kernel instance inside that database (record_id), inferred when the
+        database contains exactly one instance,
       * one GPU device (device_id),
       * and an iteration count for measured runs.
 
@@ -105,18 +106,27 @@ class BaseExecutor:
     def __init__(
         self,
         record_db: str = "",
-        record_id: str = "",
+        record_id: Optional[str] = None,
         iterations: int = 3,
         device_id: int = 0,
         warmup: int = 2,
     ):
         self.record_db = record_db
-        self.record_id = record_id
         self.device_id = device_id
+        self.records = RecordedExecution.from_json(self.record_db)
+        if record_id is None:
+            num_records = len(self.records)
+            if num_records != 1:
+                raise ValueError(
+                    f"Cannot infer record ID from '{self.record_db}': expected "
+                    f"exactly one recorded instance, found {num_records}. "
+                    "Specify -rid/--record-id."
+                )
+            record_id = next(iter(self.records))
+        self.record_id = record_id
         logger.debug(
             f"BaseExecutor Got {self.record_db} and {self.record_id} and will run on device:{self.device_id}"
         )
-        self.records = RecordedExecution.from_json(self.record_db)
         self.kernel_descr = self.records[self.record_id]
         self.device_arch = get_device_arch()
         self._epilogue = None

--- a/python/tests/cli/test_replay.py
+++ b/python/tests/cli/test_replay.py
@@ -43,16 +43,11 @@ def test_tune(recorded_execution, has_amd_gpu, has_nvidia_gpu):
 
 
 def test_replay(recorded_execution, has_amd_gpu, has_nvidia_gpu):
-    recorded_kernel = RecordedExecution.from_json(str(recorded_execution))
-    dynamic_hash = list(recorded_kernel.kernel_instances.keys())[0]
-
     result = mneme_main(
         [
             "replay",
             "-rdb",
             str(recorded_execution),
-            "-rid",
-            str(dynamic_hash),
             "default<O0>",
         ]
     )

--- a/python/tests/test_replay_executor.py
+++ b/python/tests/test_replay_executor.py
@@ -129,10 +129,12 @@ class FakeDeviceModule:
 
 
 class FakeRecordedExecution:
-    def __init__(self, kernel_descr):
+    def __init__(self, kernel_descr=None, kernel_instances=None):
         self.va_addr = 0x1000
         self.va_size = 0x2000
-        self._kernel_descr = kernel_descr
+        self.kernel_instances = (
+            {"rid": kernel_descr} if kernel_instances is None else kernel_instances
+        )
         self.link_calls = []
 
     @classmethod
@@ -140,7 +142,13 @@ class FakeRecordedExecution:
         raise RuntimeError("You must monkeypatch from_json in tests")
 
     def __getitem__(self, record_id):
-        return self._kernel_descr
+        return self.kernel_instances[record_id]
+
+    def __iter__(self):
+        return iter(self.kernel_instances)
+
+    def __len__(self):
+        return len(self.kernel_instances)
 
     def link_llvm_modules(self, prune=True, internalize=True):
         self.link_calls.append((prune, internalize))
@@ -179,6 +187,18 @@ def _reload_with_identity_decorators(monkeypatch):
     mod = importlib.import_module(MODULE_PATH)
     mod = importlib.reload(mod)
     return mod
+
+
+def _patch_executor_init_dependencies(monkeypatch, mod, records):
+    monkeypatch.setattr(
+        mod.RecordedExecution,
+        "from_json",
+        staticmethod(lambda _: records),
+        raising=True,
+    )
+    monkeypatch.setattr(mod, "set_device", lambda _: None, raising=True)
+    monkeypatch.setattr(mod, "get_device_arch", lambda: "sm", raising=True)
+    monkeypatch.setattr(mod, "get_device_count", lambda: 1, raising=True)
 
 
 # --------------------------
@@ -221,12 +241,70 @@ def test_baseexecutor_init_sets_gpu_affinity_and_loads_records(monkeypatch):
     )
 
     assert ex.records is rec
+    assert ex.record_id == "rid"
     assert ex.kernel_descr is kernel
     assert ex.device_arch == "sm_80"
     assert ex.num_devices == 8
     assert calls["set_device"] == [3]
     assert calls["from_json"] == ["db.json"]
     assert ex._iterations == 5
+
+
+def test_baseexecutor_infers_single_record_id(monkeypatch):
+    mod = _reload_with_identity_decorators(monkeypatch)
+
+    kernel = FakeKernelDescr()
+    rec = FakeRecordedExecution(kernel_instances={"only-rid": kernel})
+    _patch_executor_init_dependencies(monkeypatch, mod, rec)
+
+    ex = mod.BaseExecutor(record_db="db.json")
+
+    assert ex.record_id == "only-rid"
+    assert ex.kernel_descr is kernel
+
+
+@pytest.mark.parametrize(
+    ("record_ids", "expected_count"),
+    [([], 0), (["first", "second"], 2)],
+)
+def test_baseexecutor_rejects_ambiguous_record_id(
+    monkeypatch, record_ids, expected_count
+):
+    mod = _reload_with_identity_decorators(monkeypatch)
+
+    kernel_instances = {record_id: FakeKernelDescr() for record_id in record_ids}
+    rec = FakeRecordedExecution(kernel_instances=kernel_instances)
+    monkeypatch.setattr(
+        mod.RecordedExecution,
+        "from_json",
+        staticmethod(lambda _: rec),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        mod,
+        "get_device_arch",
+        lambda: pytest.fail("GPU initialization should not be reached"),
+        raising=True,
+    )
+
+    with pytest.raises(ValueError, match=f"found {expected_count}"):
+        mod.BaseExecutor(record_db="db.json")
+
+
+def test_baseexecutor_uses_explicit_record_id_with_multiple_instances(monkeypatch):
+    mod = _reload_with_identity_decorators(monkeypatch)
+
+    first = FakeKernelDescr(kernel_name="first")
+    selected = FakeKernelDescr(kernel_name="selected")
+    rec = FakeRecordedExecution(
+        kernel_instances={"first-rid": first, "selected-rid": selected}
+    )
+    _patch_executor_init_dependencies(monkeypatch, mod, rec)
+
+    ex = mod.BaseExecutor(record_db="db.json", record_id="selected-rid")
+
+    assert ex.record_id == "selected-rid"
+    assert ex.kernel_descr is selected
 
 
 def test_open_close_context_manager_opens_and_closes_resources(monkeypatch):


### PR DESCRIPTION
Allow replay to infer the record ID when a recording database contains exactly one kernel instance.

- Make the replay record ID optional while retaining explicit selection for multi-instance databases.
- Report a clear error when record ID inference is ambiguous.
- Update CLI and getting-started documentation for the optional record ID.
- Add coverage for inferred, ambiguous, and explicitly selected record IDs.

Closes #183