### PR TITLE
Support Binary Versioning

### DIFF
--- a/docs/dev/cpp.md
+++ b/docs/dev/cpp.md
@@ -43,3 +43,75 @@ mneme::annotate<double>(d_buf, mneme::Metadata{
 See **[Usage → Verification](../usage/verification.md)** for the full
 field reference and end-to-end examples.
 
+
+---
+
+## Snapshot file format (`mneme/MnemeSnapshotFormat.hpp`)
+
+Prologue and epilogue snapshots share one container: a 16-byte header
+followed by a payload whose layout depends on the header.
+
+| Offset | Size | Field                                         |
+|--------|------|-----------------------------------------------|
+| 0      | 8    | Magic, the ASCII bytes `MNEMESNP`             |
+| 8      | 4    | `SnapshotKind` (`Bytes = 1`, `Diff = 2`)      |
+| 12     | 4    | Layout version of the payload for that kind   |
+
+`SnapshotHeader::parse` also recognizes two legacy prefixes from before the
+container existed: files starting with `MNEME_DIFF_V1` are treated as
+`Diff` version 1, and files with no magic at all are treated as `Bytes`
+version 0. Those mappings are frozen history; do not change them.
+
+### How versions are owned
+
+Each on-disk layout is decoded by exactly one reader class, and that class
+owns its `(kind, version)` pair through a `Layout` member:
+
+```cpp
+template <DeviceVendors VendorTypes>
+class DiffReaderV1 : public SnapshotReader<VendorTypes> {
+public:
+  static constexpr SnapshotHeader Layout{SnapshotKind::Diff, 1};
+  ...
+};
+```
+
+Everything else refers to that member rather than repeating the number:
+
+- `SnapshotFormatRegistry` maps the parsed header to a reader by walking a
+  table built from `entry<ReaderT>()` rows, one per reader class.
+- The writer that produces a layout returns the matching reader's `Layout`
+  from `header()`. `FormatWriter::write` emits that header before calling
+  `writePayload`, so the stamp on disk can only ever name a layout that has
+  a decoder.
+
+### When to bump the version
+
+Bump the version whenever an existing reader would misinterpret the new
+bytes: reordering or resizing fields, changing an encoding, or adding a
+field that is not self-delimiting. Do not bump for changes that leave the
+byte stream identical.
+
+Never edit an existing reader to accept a changed layout. Old recordings
+must keep opening, and `ctest -R Serialize` exercises that.
+
+### How to bump the version
+
+Using a diff layout change as the example:
+
+1. Add `DiffReaderV2` next to `DiffReaderV1` with
+   `static constexpr SnapshotHeader Layout{SnapshotKind::Diff, 2};` and a
+   `read()` that decodes the new payload. Leave `DiffReaderV1` in place.
+2. Add `entry<DiffReaderV2<VendorTypes>>()` to the table in
+   `SnapshotFormatRegistry::table`.
+3. Change `DiffWriter::header()` to return
+   `DiffReaderV2<VendorTypes>::Layout`, and update `DiffWriter::writePayload`
+   to emit the new layout.
+4. Extend `tests/unit_tests/ReadWriteSnapshot.cpp` so the round trip covers
+   the new layout, and keep a fixture or hand-built buffer in the previous
+   layout so the old reader stays covered.
+
+The version literal appears in exactly one place, the new reader's
+`Layout`. Skipping step 2 is the one mistake the compiler cannot catch: the
+writer stamps version 2, the registry has no row for it, and opening the
+snapshot fails with `Unsupported Mneme snapshot format`.

--- a/docs/dev/cpp.md
+++ b/docs/dev/cpp.md
@@ -48,8 +48,9 @@ field reference and end-to-end examples.
 
 ## Snapshot file format (`mneme/MnemeSnapshotFormat.hpp`)
 
-Prologue and epilogue snapshots share one container: a 16-byte header
-followed by a payload whose layout depends on the header.
+Prologue and epilogue snapshots use the same container. The container has
+a 16-byte header and a payload. The header identifies the layout of the
+payload.
 
 | Offset | Size | Field                                         |
 |--------|------|-----------------------------------------------|
@@ -57,15 +58,15 @@ followed by a payload whose layout depends on the header.
 | 8      | 4    | `SnapshotKind` (`Bytes = 1`, `Diff = 2`)      |
 | 12     | 4    | Layout version of the payload for that kind   |
 
-`SnapshotHeader::parse` also recognizes two legacy prefixes from before the
-container existed: files starting with `MNEME_DIFF_V1` are treated as
-`Diff` version 1, and files with no magic at all are treated as `Bytes`
-version 0. Those mappings are frozen history; do not change them.
+`SnapshotHeader::parse` also accepts two legacy prefixes from before the
+container existed. A file that starts with `MNEME_DIFF_V1` is `Diff`
+version 1. A file with no magic is `Bytes` version 0. These two mappings
+are fixed. Do not change them.
 
 ### How versions are owned
 
-Each on-disk layout is decoded by exactly one reader class, and that class
-owns its `(kind, version)` pair through a `Layout` member:
+One reader class decodes one on-disk layout. The reader class holds its
+`(kind, version)` pair in a `Layout` member:
 
 ```cpp
 template <DeviceVendors VendorTypes>
@@ -76,42 +77,42 @@ public:
 };
 ```
 
-Everything else refers to that member rather than repeating the number:
+All other code refers to this member. The version number is written once.
 
-- `SnapshotFormatRegistry` maps the parsed header to a reader by walking a
-  table built from `entry<ReaderT>()` rows, one per reader class.
-- The writer that produces a layout returns the matching reader's `Layout`
-  from `header()`. `FormatWriter::write` emits that header before calling
-  `writePayload`, so the stamp on disk can only ever name a layout that has
-  a decoder.
+- `SnapshotFormatRegistry` holds a table with one `entry<ReaderT>()` row
+  for each reader class. It finds the row that matches the parsed header
+  and makes that reader.
+- A writer returns the `Layout` of the reader that decodes its output from
+  `header()`. `FormatWriter::write` writes this header before it calls
+  `writePayload`. A writer can only stamp a layout that has a reader.
 
 ### When to bump the version
 
-Bump the version whenever an existing reader would misinterpret the new
-bytes: reordering or resizing fields, changing an encoding, or adding a
-field that is not self-delimiting. Do not bump for changes that leave the
-byte stream identical.
+Bump the version when an existing reader would decode the new bytes
+incorrectly. Examples are a change to the order, size, or encoding of a
+field, or a new field that a reader cannot skip. Do not bump the version
+when the byte stream stays the same.
 
-Never edit an existing reader to accept a changed layout. Old recordings
-must keep opening, and `ctest -R Serialize` exercises that.
+Do not change an existing reader to accept a new layout. Old recordings
+must continue to open. `ctest -R Serialize` checks this.
 
 ### How to bump the version
 
-Using a diff layout change as the example:
+This procedure uses a change to the diff layout as the example.
 
-1. Add `DiffReaderV2` next to `DiffReaderV1` with
+1. Add `DiffReaderV2` after `DiffReaderV1`. Give it
    `static constexpr SnapshotHeader Layout{SnapshotKind::Diff, 2};` and a
-   `read()` that decodes the new payload. Leave `DiffReaderV1` in place.
+   `read()` that decodes the new payload. Keep `DiffReaderV1`.
 2. Add `entry<DiffReaderV2<VendorTypes>>()` to the table in
    `SnapshotFormatRegistry::table`.
 3. Change `DiffWriter::header()` to return
-   `DiffReaderV2<VendorTypes>::Layout`, and update `DiffWriter::writePayload`
-   to emit the new layout.
-4. Extend `tests/unit_tests/ReadWriteSnapshot.cpp` so the round trip covers
-   the new layout, and keep a fixture or hand-built buffer in the previous
-   layout so the old reader stays covered.
+   `DiffReaderV2<VendorTypes>::Layout`. Change `DiffWriter::writePayload` to
+   write the new layout.
+4. Extend `tests/unit_tests/ReadWriteSnapshot.cpp` so that the round trip
+   covers the new layout. Keep a fixture or a hand-built buffer in the old
+   layout so that the old reader stays covered.
 
-The version literal appears in exactly one place, the new reader's
-`Layout`. Skipping step 2 is the one mistake the compiler cannot catch: the
-writer stamps version 2, the registry has no row for it, and opening the
-snapshot fails with `Unsupported Mneme snapshot format`.
+The version number appears only in the new reader's `Layout`. The compiler
+cannot detect a missing step 2. In that case the writer stamps version 2,
+the registry has no row for it, and the snapshot fails to open with
+`Unsupported Mneme snapshot format`.

--- a/include/mneme/MnemeAnnotationInternal.hpp
+++ b/include/mneme/MnemeAnnotationInternal.hpp
@@ -1,10 +1,13 @@
 #pragma once
 #include "mneme/MnemeAnnotation.hpp"
+#include <cstddef>
 #include <llvm/Support/raw_ostream.h>
 
 namespace mneme {
 namespace metadata {
 void serialize(llvm::raw_ostream &OS, const Metadata &Md);
 Metadata fromBuffer(const char *&Buffer);
+// The number of bytes serialize() writes for Md.
+size_t serializedSize(const Metadata &Md);
 } // namespace metadata
 } // namespace mneme

--- a/include/mneme/MnemeKernelInfo.hpp
+++ b/include/mneme/MnemeKernelInfo.hpp
@@ -21,7 +21,7 @@ struct KernelInfo {
   llvm::SmallVector<std::unique_ptr<uint8_t[]>> ArgData;
   KernelInfo(const void *HostFun, char *Name)
       : HostFun(HostFun), Name(Name), StaticHash(std::nullopt) {};
-  KernelInfo(std::string &Name) : Name(Name), StaticHash(std::nullopt) {};
+  KernelInfo(const std::string &Name) : Name(Name), StaticHash(std::nullopt) {};
 
 public:
   void setArgSizes(llvm::ArrayRef<size_t> ArgSizes) {

--- a/include/mneme/MnemeKernelInfo.hpp
+++ b/include/mneme/MnemeKernelInfo.hpp
@@ -19,7 +19,7 @@ struct KernelInfo {
   llvm::SmallVector<std::function<double(void *)>> ToDoubleFunc;
   llvm::SmallVector<bool> KernelSpecializations;
   llvm::SmallVector<std::unique_ptr<uint8_t[]>> ArgData;
-  KernelInfo(const void *HostFun, char *Name)
+  KernelInfo(const void *HostFun, const char *Name)
       : HostFun(HostFun), Name(Name), StaticHash(std::nullopt) {};
   KernelInfo(const std::string &Name) : Name(Name), StaticHash(std::nullopt) {};
 

--- a/include/mneme/MnemeMemory.hpp
+++ b/include/mneme/MnemeMemory.hpp
@@ -13,6 +13,7 @@
 #include "mneme/MnemeAnnotationInternal.hpp"
 #include "mneme/MnemeComparators.hpp"
 #include "mneme/MnemeLogger.hpp"
+#include "mneme/MnemeSnapshotRecords.hpp"
 #include "mneme/MnemeUtils.hpp"
 
 namespace mneme {
@@ -86,16 +87,14 @@ public:
 
   static std::pair<void *, MnemeMemoryBlob<VendorTypes>>
   fromBuffer(const char *&Buffer) {
-    size_t ActualSize = util::extractScalar<size_t>(Buffer);
-    size_t Size = util::extractScalar<size_t>(Buffer);
-    void *DeviceAddr = util::extractScalar<void *>(Buffer);
-    auto Blob = MnemeMemoryBlob<VendorTypes>(ActualSize, 0, Size);
-    std::memcpy(Blob.getHostData().get(), Buffer, Size);
-    Buffer += Size;
+    BlobHeader Header = BlobHeader::read(Buffer);
+    auto Blob = MnemeMemoryBlob<VendorTypes>(Header.ActualSize, 0, Header.Size);
+    std::memcpy(Blob.getHostData().get(), Buffer, Header.Size);
+    Buffer += Header.Size;
     LOG_DEBUG("Read memory blob at address {} SIZE: {} ActualSize:{}",
-              DeviceAddr, Size, ActualSize);
+              Header.DevAddr, Header.Size, Header.ActualSize);
     Blob.PtrMD = metadata::fromBuffer(Buffer);
-    return std::make_pair(DeviceAddr, std::move(Blob));
+    return std::make_pair(Header.DevAddr, std::move(Blob));
   }
 
   void *ptr() { return reinterpret_cast<void *>(BlobAddr); }
@@ -167,12 +166,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                               const MnemeMemoryBlob<VendorTypes> &Blob) {
   // The format in the binary is the following:
   // | Var Actual Size | Var-Size | Device Address | Var Data | Metadata
-  OS << llvm::StringRef(reinterpret_cast<const char *>(&Blob.ActualSize),
-                        sizeof(Blob.ActualSize));
-  OS << llvm::StringRef(reinterpret_cast<const char *>(&Blob.Size),
-                        sizeof(Blob.Size));
-  OS << llvm::StringRef(reinterpret_cast<const char *>(&Blob.BlobAddr),
-                        sizeof(Blob.BlobAddr));
+  BlobHeader{Blob.ActualSize, Blob.Size, Blob.BlobAddr}.write(OS);
 
   LOG_DEBUG("Serializing MemoryBlob, DevAddr:{} MirroredHostAddr:{} Size:{} "
             "ActualSize:{}",

--- a/include/mneme/MnemeReplay.hpp
+++ b/include/mneme/MnemeReplay.hpp
@@ -162,8 +162,7 @@ class PrologueState : public ReplayMemState<VendorTypes> {
 public:
   PrologueState(const std::string &KernelName, const std::string &SnapshotFile)
       : ReplayMemState<VendorTypes>(
-            MnemeSnapshot<VendorTypes>::readBytesSnapshot(KernelName,
-                                                          SnapshotFile)) {}
+            BaseSnapshotSource<VendorTypes>(SnapshotFile).load(KernelName)) {}
 
   void load() override {
     for (auto &[DevAddr, MemBlob] : this->DeviceMemoryState) {
@@ -280,8 +279,8 @@ makeReplayEpilogueState(const std::string &KernelName,
                         const std::string &SnapshotFile,
                         const std::string &BasePrologueFile) {
   Snapshot<VendorTypes> Snap =
-      MnemeSnapshot<VendorTypes>::openSnapshot(SnapshotFile)
-          ->reconstruct(KernelName, BasePrologueFile);
+      SnapshotFormatRegistry<VendorTypes>::open(SnapshotFile)
+          ->read(KernelName, BaseSnapshotSource<VendorTypes>(BasePrologueFile));
   return std::make_unique<EpilogueState<VendorTypes>>(std::move(Snap));
 }
 

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -31,121 +31,18 @@
 #include "mneme/MnemeLLVMUtils.hpp"
 #include "mneme/MnemeLogger.hpp"
 #include "mneme/MnemeMemory.hpp"
+#include "mneme/MnemeSnapshotFormat.hpp"
 #include "mneme/MnemeSnapshotRecords.hpp"
 #include "mneme/MnemeUtils.hpp"
 #include <proteus/KernelMetadata.h>
 
 namespace mneme {
 
-struct ReplayGlobalVar {
-  void *HostAddr;
-  void *DevAddr;
-  uint64_t VarSize;
-  ReplayGlobalVar(void *DevAddr, uint64_t VarSize)
-      : HostAddr(new uint8_t[VarSize]), DevAddr(DevAddr), VarSize(VarSize) {}
-  ReplayGlobalVar(void *HostAddr, void *DevAddr, uint64_t VarSize)
-      : HostAddr(HostAddr), DevAddr(DevAddr), VarSize(VarSize) {}
-  ReplayGlobalVar() = delete;
-  ~ReplayGlobalVar() {
-    if (HostAddr)
-      delete[] static_cast<uint8_t *>(HostAddr);
-  }
-
-  ReplayGlobalVar(const ReplayGlobalVar &) = delete;
-  ReplayGlobalVar &operator=(const ReplayGlobalVar &) = delete;
-
-  ReplayGlobalVar(ReplayGlobalVar &&Other)
-      : HostAddr(Other.HostAddr), DevAddr(Other.DevAddr),
-        VarSize(Other.VarSize) {
-    Other.HostAddr = nullptr;
-  }
-
-  ReplayGlobalVar &operator=(ReplayGlobalVar &&Other) {
-    if (this != &Other) {
-      this->HostAddr = Other.HostAddr;
-      this->DevAddr = Other.DevAddr;
-      this->VarSize = Other.VarSize;
-      Other.HostAddr = nullptr;
-    }
-    return *this;
-  }
-};
-
-// The in-memory contents of a snapshot, as produced by the snapshot readers
-// and consumed by the replay memory state constructors.
-template <DeviceVendors VendorTypes> struct Snapshot {
-  std::shared_ptr<KernelInfo> KInfo;
-  std::unordered_map<std::string, ReplayGlobalVar> GlobalVars;
-  llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> DeviceMemory;
-};
-
-// Reads one global-variable record: its header followed by the recorded bytes
-// of the variable.
-inline std::pair<std::string, ReplayGlobalVar>
-readGlobalVarRecord(const char *&Buffer) {
-  GlobalVarHeader Header = GlobalVarHeader::read(Buffer);
-  ReplayGlobalVar RGV(Header.DevAddr, Header.Size);
-  std::memcpy(const_cast<void *>(RGV.HostAddr), Buffer, Header.Size);
-  Buffer += Header.Size;
-  LOG_DEBUG("Loaded from buffer Global, Name:{}, VarSize:{}, RecoredAddr:{}",
-            Header.Name, Header.Size, Header.DevAddr);
-  return std::pair<std::string, ReplayGlobalVar>(std::move(Header.Name),
-                                                 std::move(RGV));
-}
-
-template <DeviceVendors VendorTypes> class MnemeSnapshot;
-
-// An opened snapshot file. The concrete subclass encodes the on-disk format
-// (full "bytes" vs diff), detected from the file's magic header. reconstruct()
-// turns the held buffer into the format-independent Snapshot that the replay
-// memory states consume.
-template <DeviceVendors VendorTypes> class SnapshotFile {
-public:
-  SnapshotFile(std::string Filename, std::unique_ptr<llvm::MemoryBuffer> Buffer)
-      : Filename(std::move(Filename)), Buffer(std::move(Buffer)) {}
-  virtual ~SnapshotFile() = default;
-
-  // Reconstructs the full snapshot contents. BasePrologueFile names the base
-  // prologue snapshot a diff is applied onto; self-contained formats ignore it.
-  virtual Snapshot<VendorTypes>
-  reconstruct(const std::string &KernelName,
-              const std::string &BasePrologueFile) const = 0;
-
-protected:
-  std::string Filename;
-  std::unique_ptr<llvm::MemoryBuffer> Buffer;
-};
-
-template <DeviceVendors VendorTypes>
-class BytesSnapshotFile : public SnapshotFile<VendorTypes> {
-public:
-  using SnapshotFile<VendorTypes>::SnapshotFile;
-
-  Snapshot<VendorTypes>
-  reconstruct(const std::string &KernelName,
-              const std::string &BasePrologueFile) const override;
-};
-
-template <DeviceVendors VendorTypes>
-class DiffSnapshotFile : public SnapshotFile<VendorTypes> {
-public:
-  using SnapshotFile<VendorTypes>::SnapshotFile;
-
-  Snapshot<VendorTypes>
-  reconstruct(const std::string &KernelName,
-              const std::string &BasePrologueFile) const override;
-};
-
 template <DeviceVendors VendorTypes> class MnemeSnapshot {
-  friend class BytesSnapshotFile<VendorTypes>;
-  friend class DiffSnapshotFile<VendorTypes>;
-
   using MnemeDeviceRT = DeviceTraits<VendorTypes>;
   using DeviceError_t = typename MnemeDeviceRT::DeviceError_t;
   using DeviceStream_t = typename MnemeDeviceRT::DeviceStream_t;
   using KernelFunction_t = typename MnemeDeviceRT::KernelFunction_t;
-  static constexpr const char DiffMagic[] = "MNEME_DIFF_V1";
-  static constexpr size_t DiffMagicSize = sizeof(DiffMagic) - 1;
   static constexpr size_t DiffChunkSize = 1 << 20;
 
   class CountingRawOStream : public llvm::raw_ostream {
@@ -158,24 +55,6 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     CountingRawOStream() : llvm::raw_ostream(/*unbuffered=*/true) {}
     uint64_t bytesWritten() const { return tell(); }
   };
-
-  static bool isDiffBuffer(llvm::StringRef Buffer) {
-    return Buffer.size() >= DiffMagicSize &&
-           Buffer.take_front(DiffMagicSize) == llvm::StringRef(DiffMagic);
-  }
-
-  static std::unique_ptr<llvm::MemoryBuffer>
-  openSnapshotFile(const std::string &Filename) {
-    if (!std::filesystem::exists(Filename))
-      LOG_FATAL("Mneme Snapshot file does not exist");
-
-    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrErr =
-        llvm::MemoryBuffer::getFile(Filename);
-    if (std::error_code EC = BufferOrErr.getError())
-      LOG_FATAL("Error when opening file " + EC.message());
-
-    return std::move(BufferOrErr.get());
-  }
 
   static size_t countChangedRanges(llvm::ArrayRef<uint8_t> Base,
                                    llvm::ArrayRef<uint8_t> Current) {
@@ -281,115 +160,6 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     util::writeBytes(OS, llvm::StringRef(DiffBytes.data(), DiffBytes.size()));
   }
 
-  static void applyDiffRanges(const char *&Buffer,
-                              llvm::MutableArrayRef<uint8_t> Target,
-                              size_t NumRanges) {
-    for (size_t R = 0; R < NumRanges; ++R) {
-      size_t Offset = util::extractScalar<size_t>(Buffer);
-      size_t Size = util::extractScalar<size_t>(Buffer);
-      if (Offset > Target.size() || Size > Target.size() - Offset)
-        LOG_FATAL("Malformed Mneme diff range: offset " +
-                  std::to_string(Offset) + " size " + std::to_string(Size) +
-                  " exceeds target size " + std::to_string(Target.size()));
-      std::memcpy(Target.data() + Offset, Buffer, Size);
-      Buffer += Size;
-    }
-  }
-
-  static void readFullMnemeSnapShot(
-      llvm::MemoryBuffer *Buffer,
-      std::unordered_map<std::string, ReplayGlobalVar> &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      std::shared_ptr<KernelInfo> KInfo) {
-    auto *Start = Buffer->getBufferStart();
-    auto *CurrentPtr = Start;
-    size_t TotalGlobals = util::extractScalar<size_t>(CurrentPtr);
-    LOG_DEBUG("Snapshot contains {} Globals at location {}", TotalGlobals,
-              (uintptr_t)CurrentPtr - (uintptr_t)Start);
-    for (auto I = 0; I < TotalGlobals; I++) {
-      auto [Name, RGV] = readGlobalVarRecord(CurrentPtr);
-      GlobalVars.try_emplace(Name, std::move(RGV));
-    }
-
-    auto TotalMemBlobs = util::extractScalar<size_t>(CurrentPtr);
-
-    LOG_DEBUG("Snapshot contains {} Memory Blobs starting at location {}",
-              TotalMemBlobs, (uintptr_t)CurrentPtr - (uintptr_t)Start);
-
-    for (auto M = 0; M < TotalMemBlobs; M++) {
-      DeviceMemory.insert(MnemeMemoryBlob<VendorTypes>::fromBuffer(CurrentPtr));
-    }
-
-    // Get kernel arguments.
-    auto TotalArguments = util::extractScalar<size_t>(CurrentPtr);
-    LOG_DEBUG("Snapshot contains {} total arguments starting at location {}",
-              TotalArguments, (uintptr_t)CurrentPtr - (uintptr_t)Start);
-    KInfo->KernelArgSizes.resize(TotalArguments);
-    KInfo->ArgData.resize(TotalArguments);
-    for (auto A = 0; A < TotalArguments; A++) {
-      KInfo->KernelArgSizes[A] = util::extractScalar<size_t>(CurrentPtr);
-      KInfo->setArgData(CurrentPtr, A);
-    }
-  }
-
-  // Applies the diff ranges from DiffBuffer onto the already-loaded base
-  // prologue state held in GlobalVars and DeviceMemory.
-  static void applyDiffMnemeSnapShot(
-      const std::string &Filename,
-      std::unordered_map<std::string, ReplayGlobalVar> &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      llvm::MemoryBuffer *DiffBuffer) {
-    auto *Start = DiffBuffer->getBufferStart();
-    auto *CurrentPtr = Start + DiffMagicSize;
-    size_t TotalGlobals = util::extractScalar<size_t>(CurrentPtr);
-    if (TotalGlobals != GlobalVars.size())
-      LOG_FATAL("Mneme diff " + Filename +
-                " does not match prologue global count");
-
-    for (size_t I = 0; I < TotalGlobals; ++I) {
-      GlobalVarHeader GVH = GlobalVarHeader::read(CurrentPtr);
-      size_t NumRanges = util::extractScalar<size_t>(CurrentPtr);
-
-      auto It = GlobalVars.find(GVH.Name);
-      if (It == GlobalVars.end())
-        LOG_FATAL("Mneme diff references global missing from prologue: " +
-                  GVH.Name);
-      if (It->second.VarSize != GVH.Size)
-        LOG_FATAL("Mneme diff global size mismatch for: " + GVH.Name);
-      It->second.DevAddr = GVH.DevAddr;
-      applyDiffRanges(
-          CurrentPtr,
-          llvm::MutableArrayRef<uint8_t>(
-              static_cast<uint8_t *>(It->second.HostAddr), It->second.VarSize),
-          NumRanges);
-    }
-
-    size_t TotalMemBlobs = util::extractScalar<size_t>(CurrentPtr);
-    if (TotalMemBlobs != DeviceMemory.size())
-      LOG_FATAL("Mneme diff " + Filename +
-                " does not match prologue memory blob count");
-
-    for (size_t I = 0; I < TotalMemBlobs; ++I) {
-      BlobHeader BH = BlobHeader::read(CurrentPtr);
-      auto MD = metadata::fromBuffer(CurrentPtr);
-      size_t NumRanges = util::extractScalar<size_t>(CurrentPtr);
-
-      auto It = DeviceMemory.find(BH.DevAddr);
-      if (It == DeviceMemory.end())
-        LOG_FATAL("Mneme diff references device allocation missing from "
-                  "prologue");
-      auto &Blob = It->second;
-      if (Blob.getActualSize() != BH.ActualSize || Blob.getSize() != BH.Size)
-        LOG_FATAL("Mneme diff memory blob size mismatch");
-      Blob.setMetadata(MD);
-      applyDiffRanges(
-          CurrentPtr,
-          llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
-                                         Blob.getSize()),
-          NumRanges);
-    }
-  }
-
   static size_t computeMnemeBytesSnapshotSize(
       const proteus::runtime::GlobalMetadataMap &GlobalVars,
       const llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
@@ -418,7 +188,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
   }
 
 public:
-  using GlobalSnapshotData = std::unordered_map<std::string, std::vector<uint8_t>>;
+  using GlobalSnapshotData = mneme::GlobalSnapshotData;
 
   std::filesystem::path static takeMnemeBytesSnapshot(
       const proteus::runtime::GlobalMetadataMap &GlobalVars,
@@ -498,7 +268,7 @@ public:
       const proteus::runtime::GlobalMetadataMap &GlobalVars,
       llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       const GlobalSnapshotData &PrologueGlobals, bool UpdateBaseData) {
-    util::writeBytes(OutBC, llvm::StringRef(DiffMagic, DiffMagicSize));
+    SnapshotHeader{SnapshotKind::Diff, 1}.write(OutBC);
 
     size_t TotalGlobals = GlobalVars.size();
     util::writeScalar(OutBC, TotalGlobals);
@@ -590,62 +360,7 @@ public:
     return takeMnemeBytesSnapshot(GlobalVars, DeviceMemory, Filename,
                                   KernelArgSizes, Args, Stream);
   }
-
-  // Opens Filename and returns it as the concrete on-disk format detected from
-  // its magic header.
-  static std::unique_ptr<SnapshotFile<VendorTypes>>
-  openSnapshot(const std::string &Filename) {
-    LOG_DEBUG("Opening snapshot file {}", Filename);
-    auto Buffer = openSnapshotFile(Filename);
-    if (isDiffBuffer(Buffer->getBuffer()))
-      return std::make_unique<DiffSnapshotFile<VendorTypes>>(Filename,
-                                                             std::move(Buffer));
-    return std::make_unique<BytesSnapshotFile<VendorTypes>>(Filename,
-                                                            std::move(Buffer));
-  }
-
-  static Snapshot<VendorTypes> readBytesSnapshot(std::string KernelName,
-                                                 const std::string &Filename) {
-    return openSnapshot(Filename)->reconstruct(KernelName, "");
-  }
-
-  // Opens Filename and reconstructs it as a diff snapshot applied onto the base
-  // prologue snapshot at BasePrologueFile.
-  static Snapshot<VendorTypes>
-  readDiffSnapshot(std::string KernelName, const std::string &Filename,
-                   const std::string &BasePrologueFile) {
-    return openSnapshot(Filename)->reconstruct(KernelName, BasePrologueFile);
-  }
 };
-
-template <DeviceVendors VendorTypes>
-Snapshot<VendorTypes> BytesSnapshotFile<VendorTypes>::reconstruct(
-    const std::string &KernelName, const std::string &) const {
-  Snapshot<VendorTypes> Snap;
-  // KernelInfo's constructor takes a non-const std::string &, so name it with a
-  // mutable local.
-  std::string Name = KernelName;
-  Snap.KInfo = std::make_shared<KernelInfo>(Name);
-  MnemeSnapshot<VendorTypes>::readFullMnemeSnapShot(
-      this->Buffer.get(), Snap.GlobalVars, Snap.DeviceMemory, Snap.KInfo);
-  return Snap;
-}
-
-template <DeviceVendors VendorTypes>
-Snapshot<VendorTypes> DiffSnapshotFile<VendorTypes>::reconstruct(
-    const std::string &KernelName, const std::string &BasePrologueFile) const {
-  if (BasePrologueFile.empty())
-    LOG_FATAL("Mneme diff epilogue requires an explicit base prologue "
-              "snapshot path");
-
-  // A diff stores only changed ranges, so reconstruct the full base prologue
-  // first and then overlay the diff onto it.
-  Snapshot<VendorTypes> Snap =
-      MnemeSnapshot<VendorTypes>::readBytesSnapshot(KernelName, BasePrologueFile);
-  MnemeSnapshot<VendorTypes>::applyDiffMnemeSnapShot(
-      this->Filename, Snap.GlobalVars, Snap.DeviceMemory, this->Buffer.get());
-  return Snap;
-}
 
 struct KernelInstance {
   std::string PrologueFn;

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -31,6 +31,7 @@
 #include "mneme/MnemeLLVMUtils.hpp"
 #include "mneme/MnemeLogger.hpp"
 #include "mneme/MnemeMemory.hpp"
+#include "mneme/MnemeSnapshotRecords.hpp"
 #include "mneme/MnemeUtils.hpp"
 #include <proteus/KernelMetadata.h>
 
@@ -77,6 +78,20 @@ template <DeviceVendors VendorTypes> struct Snapshot {
   std::unordered_map<std::string, ReplayGlobalVar> GlobalVars;
   llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> DeviceMemory;
 };
+
+// Reads one global-variable record: its header followed by the recorded bytes
+// of the variable.
+inline std::pair<std::string, ReplayGlobalVar>
+readGlobalVarRecord(const char *&Buffer) {
+  GlobalVarHeader Header = GlobalVarHeader::read(Buffer);
+  ReplayGlobalVar RGV(Header.DevAddr, Header.Size);
+  std::memcpy(const_cast<void *>(RGV.HostAddr), Buffer, Header.Size);
+  Buffer += Header.Size;
+  LOG_DEBUG("Loaded from buffer Global, Name:{}, VarSize:{}, RecoredAddr:{}",
+            Header.Name, Header.Size, Header.DevAddr);
+  return std::pair<std::string, ReplayGlobalVar>(std::move(Header.Name),
+                                                 std::move(RGV));
+}
 
 template <DeviceVendors VendorTypes> class MnemeSnapshot;
 
@@ -292,7 +307,7 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     LOG_DEBUG("Snapshot contains {} Globals at location {}", TotalGlobals,
               (uintptr_t)CurrentPtr - (uintptr_t)Start);
     for (auto I = 0; I < TotalGlobals; I++) {
-      auto [Name, RGV] = fromBuffer(CurrentPtr);
+      auto [Name, RGV] = readGlobalVarRecord(CurrentPtr);
       GlobalVars.try_emplace(Name, std::move(RGV));
     }
 
@@ -332,18 +347,16 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
                 " does not match prologue global count");
 
     for (size_t I = 0; I < TotalGlobals; ++I) {
-      std::string Name = util::readSizedString(CurrentPtr);
-      size_t VarSize = util::extractScalar<size_t>(CurrentPtr);
-      void *DevAddr = util::extractScalar<void *>(CurrentPtr);
+      GlobalVarHeader GVH = GlobalVarHeader::read(CurrentPtr);
       size_t NumRanges = util::extractScalar<size_t>(CurrentPtr);
 
-      auto It = GlobalVars.find(Name);
+      auto It = GlobalVars.find(GVH.Name);
       if (It == GlobalVars.end())
         LOG_FATAL("Mneme diff references global missing from prologue: " +
-                  Name);
-      if (It->second.VarSize != VarSize)
-        LOG_FATAL("Mneme diff global size mismatch for: " + Name);
-      It->second.DevAddr = DevAddr;
+                  GVH.Name);
+      if (It->second.VarSize != GVH.Size)
+        LOG_FATAL("Mneme diff global size mismatch for: " + GVH.Name);
+      It->second.DevAddr = GVH.DevAddr;
       applyDiffRanges(
           CurrentPtr,
           llvm::MutableArrayRef<uint8_t>(
@@ -357,18 +370,16 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
                 " does not match prologue memory blob count");
 
     for (size_t I = 0; I < TotalMemBlobs; ++I) {
-      size_t ActualSize = util::extractScalar<size_t>(CurrentPtr);
-      size_t Size = util::extractScalar<size_t>(CurrentPtr);
-      void *DeviceAddr = util::extractScalar<void *>(CurrentPtr);
+      BlobHeader BH = BlobHeader::read(CurrentPtr);
       auto MD = metadata::fromBuffer(CurrentPtr);
       size_t NumRanges = util::extractScalar<size_t>(CurrentPtr);
 
-      auto It = DeviceMemory.find(DeviceAddr);
+      auto It = DeviceMemory.find(BH.DevAddr);
       if (It == DeviceMemory.end())
         LOG_FATAL("Mneme diff references device allocation missing from "
                   "prologue");
       auto &Blob = It->second;
-      if (Blob.getActualSize() != ActualSize || Blob.getSize() != Size)
+      if (Blob.getActualSize() != BH.ActualSize || Blob.getSize() != BH.Size)
         LOG_FATAL("Mneme diff memory blob size mismatch");
       Blob.setMetadata(MD);
       applyDiffRanges(
@@ -379,32 +390,23 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
     }
   }
 
-  static size_t getSerializedMetadataSize(const Metadata &MD) {
-    return sizeof(std::underlying_type_t<BuiltinDType>) + sizeof(double) +
-           sizeof(ThresholdKind) + sizeof(Norm) + sizeof(size_t) +
-           (MD.tag ? MD.tag->size() : 0);
-  }
-
   static size_t computeMnemeBytesSnapshotSize(
       const proteus::runtime::GlobalMetadataMap &GlobalVars,
       const llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
       llvm::ArrayRef<size_t> KernelArgSizes) {
     size_t Size = sizeof(size_t);
     for (const auto &[VarName, GV] : GlobalVars) {
-      Size += sizeof(size_t);
-      Size += VarName.size();
-      Size += sizeof(GV.VarSize);
-      Size += sizeof(GV.DevAddr);
+      Size +=
+          GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
+              .serializedSize();
       Size += GV.VarSize;
     }
 
     Size += sizeof(size_t);
     for (const auto &[Ptr, Blob] : DeviceMemory) {
-      Size += sizeof(size_t);
-      Size += sizeof(size_t);
-      Size += sizeof(void *);
+      Size += BlobHeader::serializedSize();
       Size += Blob.getSize();
-      Size += getSerializedMetadataSize(Blob.getMetadata());
+      Size += metadata::serializedSize(Blob.getMetadata());
     }
 
     Size += sizeof(size_t);
@@ -417,20 +419,6 @@ template <DeviceVendors VendorTypes> class MnemeSnapshot {
 
 public:
   using GlobalSnapshotData = std::unordered_map<std::string, std::vector<uint8_t>>;
-
-  static std::pair<std::string, ReplayGlobalVar>
-  fromBuffer(const char *&Buffer) {
-    std::string Name = util::readSizedString(Buffer);
-    size_t VarSize = util::extractScalar<size_t>(Buffer);
-    void *DevAddr = util::extractScalar<void *>(Buffer);
-    ReplayGlobalVar RGV(DevAddr, VarSize);
-    std::memcpy(const_cast<void *>(RGV.HostAddr), Buffer, VarSize);
-    Buffer += VarSize;
-    LOG_DEBUG("Loaded from buffer Global, Name:{}, VarSize:{}, RecoredAddr:{}",
-              Name, VarSize, DevAddr);
-    return std::pair<std::string, ReplayGlobalVar>(std::move(Name),
-                                                   std::move(RGV));
-  }
 
   std::filesystem::path static takeMnemeBytesSnapshot(
       const proteus::runtime::GlobalMetadataMap &GlobalVars,
@@ -468,14 +456,8 @@ public:
         LOG_FATAL("Copying from device to host for global variables failed\n");
       }
 
-      size_t StrLen = VarName.size();
-      OutBC << llvm::StringRef(reinterpret_cast<const char *>(&StrLen),
-                               sizeof(StrLen));
-      OutBC << VarName;
-      OutBC << llvm::StringRef(reinterpret_cast<const char *>(&GV.VarSize),
-                               sizeof(GV.VarSize));
-      OutBC << llvm::StringRef(reinterpret_cast<const char *>(&GV.DevAddr),
-                               sizeof(GV.DevAddr));
+      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
+          .write(OutBC);
       OutBC << llvm::StringRef(reinterpret_cast<const char *>(HostData.get()),
                                GV.VarSize);
       if (CapturedGlobals)
@@ -535,11 +517,8 @@ public:
       if (DEC)
         LOG_FATAL("Copying from device to host for global diff failed\n");
 
-      size_t StrLen = VarName.size();
-      util::writeScalar(OutBC, StrLen);
-      util::writeBytes(OutBC, llvm::StringRef(VarName.data(), StrLen));
-      util::writeScalar(OutBC, GV.VarSize);
-      util::writeScalar(OutBC, GV.DevAddr);
+      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
+          .write(OutBC);
       size_t NumRanges = countChangedRanges(BaseIt->second, Current);
       util::writeScalar(OutBC, NumRanges);
       writeChangedRanges(OutBC, BaseIt->second, Current, 0);
@@ -548,10 +527,8 @@ public:
     size_t TotalBlobs = DeviceMemory.size();
     util::writeScalar(OutBC, TotalBlobs);
     for (auto &[Ptr, Blob] : DeviceMemory) {
-      util::writeScalar(OutBC, Blob.getActualSize());
-      util::writeScalar(OutBC, Blob.getSize());
-      auto *BlobAddr = Blob.getBlobAddr();
-      util::writeScalar(OutBC, BlobAddr);
+      BlobHeader{Blob.getActualSize(), Blob.getSize(), Blob.getBlobAddr()}
+          .write(OutBC);
       auto MD = Blob.getMetadata();
       mneme::metadata::serialize(OutBC, MD);
 

--- a/include/mneme/MnemeSnapshot.hpp
+++ b/include/mneme/MnemeSnapshot.hpp
@@ -38,330 +38,6 @@
 
 namespace mneme {
 
-template <DeviceVendors VendorTypes> class MnemeSnapshot {
-  using MnemeDeviceRT = DeviceTraits<VendorTypes>;
-  using DeviceError_t = typename MnemeDeviceRT::DeviceError_t;
-  using DeviceStream_t = typename MnemeDeviceRT::DeviceStream_t;
-  using KernelFunction_t = typename MnemeDeviceRT::KernelFunction_t;
-  static constexpr size_t DiffChunkSize = 1 << 20;
-
-  class CountingRawOStream : public llvm::raw_ostream {
-    uint64_t Pos = 0;
-
-    void write_impl(const char *, size_t Size) override { Pos += Size; }
-    uint64_t current_pos() const override { return Pos; }
-
-  public:
-    CountingRawOStream() : llvm::raw_ostream(/*unbuffered=*/true) {}
-    uint64_t bytesWritten() const { return tell(); }
-  };
-
-  static size_t countChangedRanges(llvm::ArrayRef<uint8_t> Base,
-                                   llvm::ArrayRef<uint8_t> Current) {
-    if (Base.size() != Current.size())
-      LOG_FATAL("Cannot diff buffers with different sizes");
-
-    // Count the number of contiguous ranges that have changed between Base and
-    // Current. We want to write out the number of ranges so that the reader 
-    // can know how many ranges to read.
-    size_t Count = 0;
-    bool InRange = false;
-    for (size_t I = 0; I < Base.size(); ++I) {
-      if (Base[I] != Current[I]) {
-        if (!InRange) {
-          Count++;
-          InRange = true;
-        }
-      } else {
-        InRange = false;
-      }
-    }
-    return Count;
-  }
-
-  static size_t
-  writeChangedRanges(llvm::raw_ostream &OS, llvm::ArrayRef<uint8_t> Base,
-                     llvm::ArrayRef<uint8_t> Current, size_t BaseOffset,
-                     llvm::MutableArrayRef<uint8_t> UpdateBase = {}) {
-    if (Base.size() != Current.size())
-      LOG_FATAL("Cannot diff buffers with different sizes");
-    if (!UpdateBase.empty() && UpdateBase.size() != Base.size())
-      LOG_FATAL("Cannot update diff base with mismatched buffer size");
-
-    // Write out the contiguous ranges that have changed between Base 
-    // and Current.
-    size_t Count = 0;
-    size_t I = 0;
-    while (I < Base.size()) {
-      while (I < Base.size() && Base[I] == Current[I])
-        ++I;
-      if (I == Base.size())
-        break;
-
-      size_t Start = I;
-      while (I < Base.size() && Base[I] != Current[I])
-        ++I;
-
-      size_t Offset = BaseOffset + Start;
-      size_t Len = I - Start;
-      util::writeScalar(OS, Offset);
-      util::writeScalar(OS, Len);
-      util::writeBytes(OS, Current.slice(Start, Len));
-      if (!UpdateBase.empty())
-        std::memcpy(UpdateBase.data() + Start, Current.data() + Start, Len);
-      ++Count;
-    }
-    return Count;
-  }
-
-  static void writeCountAndWriteChangedRanges(
-      llvm::raw_ostream &OS, MnemeMemoryBlob<VendorTypes> &Blob,
-      bool UpdateBaseData = true) {
-    auto Size = Blob.getSize();
-
-    // early exit
-    if (Size == 0) {
-      size_t NumRanges = 0;
-      util::writeScalar(OS, NumRanges);
-      return;
-    }
-
-    std::unique_ptr<uint8_t[]> Scratch(new uint8_t[DiffChunkSize]);
-    llvm::SmallVector<char, 0> DiffBytes;
-    llvm::raw_svector_ostream DiffOS(DiffBytes);
-    auto *Base = Blob.getHostData().get();
-    auto *DevAddr = static_cast<uint8_t *>(Blob.getBlobAddr());
-    size_t NumRanges = 0;
-
-    for (size_t Offset = 0; Offset < Size; Offset += DiffChunkSize) {
-      size_t ChunkSize = std::min(DiffChunkSize, Size - Offset);
-      auto EC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-          DeviceTraits<VendorTypes>::DeviceCopy(
-              Scratch.get(), DevAddr + Offset, ChunkSize,
-              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
-      if (EC)
-        LOG_FATAL("Error in copying data from device when writing diff\n"
-                  "Device Error Msg: " +
-                  EC.value() + "\n");
-
-      llvm::ArrayRef<uint8_t> ChunkBase(Base + Offset, ChunkSize);
-      llvm::ArrayRef<uint8_t> ChunkCurrent(Scratch.get(), ChunkSize);
-      if (UpdateBaseData) {
-        llvm::MutableArrayRef<uint8_t> UpdateBase(Base + Offset, ChunkSize);
-        NumRanges += writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset,
-                                        UpdateBase);
-      } else {
-        NumRanges +=
-            writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset);
-      }
-    }
-
-    util::writeScalar(OS, NumRanges);
-    util::writeBytes(OS, llvm::StringRef(DiffBytes.data(), DiffBytes.size()));
-  }
-
-  static size_t computeMnemeBytesSnapshotSize(
-      const proteus::runtime::GlobalMetadataMap &GlobalVars,
-      const llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      llvm::ArrayRef<size_t> KernelArgSizes) {
-    size_t Size = sizeof(size_t);
-    for (const auto &[VarName, GV] : GlobalVars) {
-      Size +=
-          GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
-              .serializedSize();
-      Size += GV.VarSize;
-    }
-
-    Size += sizeof(size_t);
-    for (const auto &[Ptr, Blob] : DeviceMemory) {
-      Size += BlobHeader::serializedSize();
-      Size += Blob.getSize();
-      Size += metadata::serializedSize(Blob.getMetadata());
-    }
-
-    Size += sizeof(size_t);
-    for (size_t ArgSize : KernelArgSizes) {
-      Size += sizeof(size_t);
-      Size += ArgSize;
-    }
-    return Size;
-  }
-
-public:
-  using GlobalSnapshotData = mneme::GlobalSnapshotData;
-
-  std::filesystem::path static takeMnemeBytesSnapshot(
-      const proteus::runtime::GlobalMetadataMap &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      std::filesystem::path &Filename,
-      llvm::SmallVector<size_t> &KernelArgSizes, void **Args,
-      DeviceStream_t Stream, GlobalSnapshotData *CapturedGlobals = nullptr) {
-    LOG_DEBUG("Storing mneme snapshot: {}", Filename.string());
-    std::error_code EC;
-    // Syncrhonize cause we need to get a consistent GPU state.
-    // We may want to do a DeviceSynchronize().
-    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
-    if (DEC)
-      LOG_FATAL("Synnchronizing stream  failed");
-    llvm::raw_fd_ostream OutBC(Filename.string(), EC);
-    // First write Global Variables.
-    size_t TotalGlobals = GlobalVars.size();
-    OutBC << llvm::StringRef(reinterpret_cast<const char *>(&TotalGlobals),
-                             sizeof(size_t));
-
-    LOG_DEBUG("Number of Globals in snapshot:{} stored at position:{}",
-              TotalGlobals, OutBC.tell());
-
-    for (const auto &[VarName, GV] : GlobalVars) {
-      std::cout << "Reading " << VarName << " " << GV.HostAddr << " "
-                << GV.DevAddr << " " << GV.VarSize << "\n";
-      std::unique_ptr<uint8_t[]> HostData(new uint8_t[GV.VarSize]);
-      auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-          DeviceTraits<VendorTypes>::DeviceCopy(
-              HostData.get(), const_cast<void *>(GV.DevAddr), GV.VarSize,
-              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
-      if (DEC) {
-        std::cout << DEC.value() << "\n";
-        LOG_FATAL("Copying from device to host for global variables failed\n");
-      }
-
-      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
-          .write(OutBC);
-      OutBC << llvm::StringRef(reinterpret_cast<const char *>(HostData.get()),
-                               GV.VarSize);
-      if (CapturedGlobals)
-        (*CapturedGlobals)[VarName] =
-            std::vector<uint8_t>(HostData.get(), HostData.get() + GV.VarSize);
-    }
-
-    size_t TotalBlobs = DeviceMemory.size();
-    LOG_DEBUG("Number of Memory Blobs in snapshot:{} stored at position:{}",
-              TotalBlobs, OutBC.tell());
-
-    OutBC << llvm::StringRef(reinterpret_cast<const char *>(&TotalBlobs),
-                             sizeof(size_t));
-
-    // Write the Device Memory
-    for (auto &[Ptr, Blob] : DeviceMemory)
-      OutBC << Blob;
-    // Lastly write the arguments
-    size_t NumArgs = KernelArgSizes.size();
-    LOG_DEBUG("Number of Kernel Arguments in snapshot:{} stored at position:{}",
-              NumArgs, OutBC.tell());
-
-    OutBC << llvm::StringRef(reinterpret_cast<const char *>(&NumArgs),
-                             sizeof(NumArgs));
-
-    for (int I = 0; I < NumArgs; I++) {
-      OutBC << llvm::StringRef(
-          reinterpret_cast<const char *>(&KernelArgSizes[I]), sizeof(size_t));
-      OutBC << llvm::StringRef(reinterpret_cast<const char *>(Args[I]),
-                               KernelArgSizes[I]);
-    }
-
-    return Filename.filename();
-  }
-
-  static void writeMnemeDiffSnapshot(
-      llvm::raw_ostream &OutBC,
-      const proteus::runtime::GlobalMetadataMap &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      const GlobalSnapshotData &PrologueGlobals, bool UpdateBaseData) {
-    SnapshotHeader{SnapshotKind::Diff, 1}.write(OutBC);
-
-    size_t TotalGlobals = GlobalVars.size();
-    util::writeScalar(OutBC, TotalGlobals);
-    for (const auto &[VarName, GV] : GlobalVars) {
-      auto BaseIt = PrologueGlobals.find(VarName);
-      if (BaseIt == PrologueGlobals.end())
-        LOG_FATAL("Cannot diff global missing from prologue: " + VarName);
-      if (BaseIt->second.size() != GV.VarSize)
-        LOG_FATAL("Cannot diff global with size mismatch: " + VarName);
-
-      std::vector<uint8_t> Current(GV.VarSize);
-      auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-          DeviceTraits<VendorTypes>::DeviceCopy(
-              Current.data(), const_cast<void *>(GV.DevAddr), GV.VarSize,
-              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
-      if (DEC)
-        LOG_FATAL("Copying from device to host for global diff failed\n");
-
-      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
-          .write(OutBC);
-      size_t NumRanges = countChangedRanges(BaseIt->second, Current);
-      util::writeScalar(OutBC, NumRanges);
-      writeChangedRanges(OutBC, BaseIt->second, Current, 0);
-    }
-
-    size_t TotalBlobs = DeviceMemory.size();
-    util::writeScalar(OutBC, TotalBlobs);
-    for (auto &[Ptr, Blob] : DeviceMemory) {
-      BlobHeader{Blob.getActualSize(), Blob.getSize(), Blob.getBlobAddr()}
-          .write(OutBC);
-      auto MD = Blob.getMetadata();
-      mneme::metadata::serialize(OutBC, MD);
-
-      writeCountAndWriteChangedRanges(OutBC, Blob, UpdateBaseData);
-    }
-  }
-
-  static size_t measureMnemeDiffSnapshotSize(
-      const proteus::runtime::GlobalMetadataMap &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
-    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
-    if (DEC)
-      LOG_FATAL("Synchronizing stream failed before diff snapshot");
-
-    CountingRawOStream Counter;
-    writeMnemeDiffSnapshot(Counter, GlobalVars, DeviceMemory, PrologueGlobals,
-                           false);
-    return Counter.bytesWritten();
-  }
-
-  std::filesystem::path static takeMnemeDiffSnapshot(
-      const proteus::runtime::GlobalMetadataMap &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      std::filesystem::path &Filename,
-      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
-    LOG_DEBUG("Storing mneme diff snapshot: {}", Filename.string());
-    std::error_code EC;
-    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
-    if (DEC)
-      LOG_FATAL("Synchronizing stream failed before diff snapshot");
-
-    llvm::raw_fd_ostream OutBC(Filename.string(), EC);
-    if (EC)
-      LOG_FATAL("Cannot write Mneme diff snapshot: " + EC.message());
-
-    writeMnemeDiffSnapshot(OutBC, GlobalVars, DeviceMemory, PrologueGlobals,
-                           true);
-    return Filename.filename();
-  }
-
-  std::filesystem::path static takeBestMnemeSnapshot(
-      const proteus::runtime::GlobalMetadataMap &GlobalVars,
-      llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory,
-      std::filesystem::path &Filename,
-      llvm::SmallVector<size_t> &KernelArgSizes, void **Args,
-      const GlobalSnapshotData &PrologueGlobals, DeviceStream_t Stream) {
-    size_t BytesSize =
-        computeMnemeBytesSnapshotSize(GlobalVars, DeviceMemory, KernelArgSizes);
-    size_t DiffSize = measureMnemeDiffSnapshotSize(GlobalVars, DeviceMemory,
-                                                   PrologueGlobals, Stream);
-
-    if (DiffSize <= BytesSize)
-      return takeMnemeDiffSnapshot(GlobalVars, DeviceMemory, Filename,
-                                   PrologueGlobals, Stream);
-
-    return takeMnemeBytesSnapshot(GlobalVars, DeviceMemory, Filename,
-                                  KernelArgSizes, Args, Stream);
-  }
-};
-
 struct KernelInstance {
   std::string PrologueFn;
   std::string EpilogueFn;
@@ -541,21 +217,21 @@ public:
                                     std::to_string(StaticHash) + "." +
                                     std::to_string(DynamicHash) + ".mneme"));
 
-    using SnapshotT = MnemeSnapshot<VendorTypes>;
-    auto PrologueGlobals =
-        std::make_shared<typename SnapshotT::GlobalSnapshotData>();
+    auto PrologueGlobals = std::make_shared<GlobalSnapshotData>();
+    SnapshotInput<VendorTypes> In{GlobalVars, DeviceMemory, KernelArgSizes,
+                                  Args, Stream};
     Instances[DynamicHash].PrologueFn =
-        SnapshotT::takeMnemeBytesSnapshot(GlobalVars, DeviceMemory, Filename,
-                                          KernelArgSizes, Args, Stream,
-                                          PrologueGlobals.get())
-            .string();
+        BytesWriter<VendorTypes>(PrologueGlobals).write(Filename, In).string();
+
+    // std::function requires a copyable callable, so the writer is shared.
+    std::shared_ptr<SnapshotWriter<VendorTypes>> Writer =
+        makeEpilogueWriter<VendorTypes>(EpilogueType, PrologueGlobals);
 
     std::function<void(llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &,
                        void **,
                        typename DeviceTraits<VendorTypes>::DeviceStream_t)>
         CaptureEpilogue =
-            [this, DynamicHash, StaticHash, MnemeDir, PrologueGlobals,
-             GlobalVars, EpilogueType](
+            [this, DynamicHash, StaticHash, MnemeDir, GlobalVars, Writer](
                 llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>>
                     &DeviceMemory,
                 void **Args,
@@ -565,29 +241,10 @@ public:
                               std::to_string(StaticHash) + "." +
                               std::to_string(DynamicHash) + ".mneme"));
 
-              switch (EpilogueType) {
-              case EpilogueSnapshotType::Bytes:
-                Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeBytesSnapshot(
-                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
-                        Args, Stream)
-                        .string();
-                break;
-              case EpilogueSnapshotType::Diff:
-                Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeMnemeDiffSnapshot(
-                        GlobalVars, DeviceMemory, Filename, *PrologueGlobals,
-                        Stream)
-                        .string();
-                break;
-              case EpilogueSnapshotType::Best:
-                Instances[DynamicHash].EpilogueFn =
-                    SnapshotT::takeBestMnemeSnapshot(
-                        GlobalVars, DeviceMemory, Filename, KernelArgSizes,
-                        Args, *PrologueGlobals, Stream)
-                        .string();
-                break;
-              }
+              SnapshotInput<VendorTypes> In{GlobalVars, DeviceMemory,
+                                            KernelArgSizes, Args, Stream};
+              Instances[DynamicHash].EpilogueFn =
+                  Writer->write(Filename, In).string();
             };
     return CaptureEpilogue;
   }

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -187,10 +187,7 @@ public:
   read(const std::string &KernelName,
        const BaseSnapshotSource<VendorTypes> &) const override {
     Snapshot<VendorTypes> Snap;
-    // KernelInfo's constructor takes a non-const std::string &, so name it with
-    // a mutable local.
-    std::string Name = KernelName;
-    Snap.KInfo = std::make_shared<KernelInfo>(Name);
+    Snap.KInfo = std::make_shared<KernelInfo>(KernelName);
 
     auto &GlobalVars = Snap.GlobalVars;
     auto &DeviceMemory = Snap.DeviceMemory;

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -10,16 +11,19 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include "mneme/DeviceTraits.hpp"
+#include "mneme/MnemeConfig.hpp"
 #include "mneme/MnemeKernelInfo.hpp"
 #include "mneme/MnemeLogger.hpp"
 #include "mneme/MnemeMemory.hpp"
 #include "mneme/MnemeSnapshotRecords.hpp"
 #include "mneme/MnemeUtils.hpp"
+#include <proteus/KernelMetadata.h>
 
 namespace mneme {
 
@@ -77,8 +81,7 @@ readGlobalVarRecord(const char *&Buffer) {
                                                  std::move(RGV));
 }
 
-// A host copy of every global a prologue captured, keyed by variable name. The
-// diff writer uses it as the base its ranges are computed against.
+// Host copies of the globals a prologue captured; the diff writer's base.
 using GlobalSnapshotData =
     std::unordered_map<std::string, std::vector<uint8_t>>;
 
@@ -389,6 +392,412 @@ BaseSnapshotSource<VendorTypes>::load(const std::string &KernelName) const {
               " cannot be used as a base because it is not self-contained");
 
   return Reader->read(KernelName, BaseSnapshotSource<VendorTypes>());
+}
+
+template <DeviceVendors VendorTypes> struct SnapshotInput {
+  const proteus::runtime::GlobalMetadataMap &GlobalVars;
+  llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> &DeviceMemory;
+  llvm::ArrayRef<size_t> KernelArgSizes;
+  void **Args;
+  typename DeviceTraits<VendorTypes>::DeviceStream_t Stream;
+};
+
+// Which writer is used is a config choice, not a property of any file.
+template <DeviceVendors VendorTypes> class SnapshotWriter {
+public:
+  virtual ~SnapshotWriter() = default;
+
+  // Returns the basename of the written file.
+  virtual std::filesystem::path
+  write(const std::filesystem::path &Filename,
+        const SnapshotInput<VendorTypes> &In) const = 0;
+
+  // The exact size write() would produce. Must not mutate any diff base.
+  virtual size_t measure(const SnapshotInput<VendorTypes> &In) const = 0;
+};
+
+// One on-disk format: a SnapshotHeader followed by a payload.
+template <DeviceVendors VendorTypes>
+class FormatWriter : public SnapshotWriter<VendorTypes> {
+public:
+  std::filesystem::path
+  write(const std::filesystem::path &Filename,
+        const SnapshotInput<VendorTypes> &In) const final {
+    LOG_DEBUG("Storing mneme snapshot: {}", Filename.string());
+    synchronize(In.Stream);
+
+    std::error_code EC;
+    llvm::raw_fd_ostream OS(Filename.string(), EC);
+    if (EC)
+      LOG_FATAL("Cannot write Mneme snapshot: " + EC.message());
+
+    header().write(OS);
+    writePayload(OS, In, /*UpdateBase=*/true);
+    return Filename.filename();
+  }
+
+  size_t measure(const SnapshotInput<VendorTypes> &In) const override {
+    synchronize(In.Stream);
+
+    CountingRawOStream Counter;
+    header().write(Counter);
+    writePayload(Counter, In, /*UpdateBase=*/false);
+    return Counter.bytesWritten();
+  }
+
+protected:
+  virtual SnapshotHeader header() const = 0;
+
+  // measure() passes UpdateBase=false so measuring never advances a diff base.
+  virtual void writePayload(llvm::raw_ostream &OS,
+                            const SnapshotInput<VendorTypes> &In,
+                            bool UpdateBase) const = 0;
+
+  static void
+  synchronize(typename DeviceTraits<VendorTypes>::DeviceStream_t Stream) {
+    // Synchronize because we need a consistent GPU state. We may want to do a
+    // DeviceSynchronize().
+    auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+        DeviceTraits<VendorTypes>::DeviceStreamSynchronize(Stream));
+    if (DEC)
+      LOG_FATAL("Synchronizing stream failed before snapshot");
+  }
+
+  class CountingRawOStream : public llvm::raw_ostream {
+    uint64_t Pos = 0;
+
+    void write_impl(const char *, size_t Size) override { Pos += Size; }
+    uint64_t current_pos() const override { return Pos; }
+
+  public:
+    CountingRawOStream() : llvm::raw_ostream(/*unbuffered=*/true) {}
+    uint64_t bytesWritten() const { return tell(); }
+  };
+};
+
+template <DeviceVendors VendorTypes>
+class BytesWriter : public FormatWriter<VendorTypes> {
+public:
+  // CaptureGlobals, when set, receives the written globals as a diff base.
+  explicit BytesWriter(
+      std::shared_ptr<GlobalSnapshotData> CaptureGlobals = nullptr)
+      : CaptureGlobals(std::move(CaptureGlobals)) {}
+
+  // Computed from the layout because a counting pass would copy every blob to
+  // the host just to measure it.
+  size_t measure(const SnapshotInput<VendorTypes> &In) const override {
+    typename FormatWriter<VendorTypes>::CountingRawOStream Counter;
+    this->header().write(Counter);
+    size_t Size = Counter.bytesWritten();
+
+    Size += sizeof(size_t);
+    for (const auto &[VarName, GV] : In.GlobalVars) {
+      Size +=
+          GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
+              .serializedSize();
+      Size += GV.VarSize;
+    }
+
+    Size += sizeof(size_t);
+    for (const auto &[Ptr, Blob] : In.DeviceMemory) {
+      Size += BlobHeader::serializedSize();
+      Size += Blob.getSize();
+      Size += metadata::serializedSize(Blob.getMetadata());
+    }
+
+    Size += sizeof(size_t);
+    for (size_t ArgSize : In.KernelArgSizes) {
+      Size += sizeof(size_t);
+      Size += ArgSize;
+    }
+    return Size;
+  }
+
+protected:
+  SnapshotHeader header() const override {
+    return SnapshotHeader{SnapshotKind::Bytes, 0};
+  }
+
+  void writePayload(llvm::raw_ostream &OutBC,
+                    const SnapshotInput<VendorTypes> &In, bool) const override {
+    const auto &GlobalVars = In.GlobalVars;
+    auto &DeviceMemory = In.DeviceMemory;
+    auto KernelArgSizes = In.KernelArgSizes;
+    void **Args = In.Args;
+
+    // First write Global Variables.
+    size_t TotalGlobals = GlobalVars.size();
+    OutBC << llvm::StringRef(reinterpret_cast<const char *>(&TotalGlobals),
+                             sizeof(size_t));
+
+    LOG_DEBUG("Number of Globals in snapshot:{} stored at position:{}",
+              TotalGlobals, OutBC.tell());
+
+    for (const auto &[VarName, GV] : GlobalVars) {
+      std::cout << "Reading " << VarName << " " << GV.HostAddr << " "
+                << GV.DevAddr << " " << GV.VarSize << "\n";
+      std::unique_ptr<uint8_t[]> HostData(new uint8_t[GV.VarSize]);
+      auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+          DeviceTraits<VendorTypes>::DeviceCopy(
+              HostData.get(), const_cast<void *>(GV.DevAddr), GV.VarSize,
+              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
+      if (DEC) {
+        std::cout << DEC.value() << "\n";
+        LOG_FATAL("Copying from device to host for global variables failed\n");
+      }
+
+      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
+          .write(OutBC);
+      OutBC << llvm::StringRef(reinterpret_cast<const char *>(HostData.get()),
+                               GV.VarSize);
+      if (CaptureGlobals)
+        (*CaptureGlobals)[VarName] =
+            std::vector<uint8_t>(HostData.get(), HostData.get() + GV.VarSize);
+    }
+
+    size_t TotalBlobs = DeviceMemory.size();
+    LOG_DEBUG("Number of Memory Blobs in snapshot:{} stored at position:{}",
+              TotalBlobs, OutBC.tell());
+
+    OutBC << llvm::StringRef(reinterpret_cast<const char *>(&TotalBlobs),
+                             sizeof(size_t));
+
+    // Write the Device Memory
+    for (auto &[Ptr, Blob] : DeviceMemory)
+      OutBC << Blob;
+    // Lastly write the arguments
+    size_t NumArgs = KernelArgSizes.size();
+    LOG_DEBUG("Number of Kernel Arguments in snapshot:{} stored at position:{}",
+              NumArgs, OutBC.tell());
+
+    OutBC << llvm::StringRef(reinterpret_cast<const char *>(&NumArgs),
+                             sizeof(NumArgs));
+
+    for (int I = 0; I < NumArgs; I++) {
+      OutBC << llvm::StringRef(
+          reinterpret_cast<const char *>(&KernelArgSizes[I]), sizeof(size_t));
+      OutBC << llvm::StringRef(reinterpret_cast<const char *>(Args[I]),
+                               KernelArgSizes[I]);
+    }
+  }
+
+private:
+  std::shared_ptr<GlobalSnapshotData> CaptureGlobals;
+};
+
+template <DeviceVendors VendorTypes>
+class DiffWriter : public FormatWriter<VendorTypes> {
+public:
+  explicit DiffWriter(std::shared_ptr<const GlobalSnapshotData> PrologueGlobals)
+      : PrologueGlobals(std::move(PrologueGlobals)) {
+    if (!this->PrologueGlobals)
+      LOG_FATAL("A Mneme diff snapshot needs the prologue globals to diff "
+                "against");
+  }
+
+protected:
+  SnapshotHeader header() const override {
+    return SnapshotHeader{SnapshotKind::Diff, 1};
+  }
+
+  void writePayload(llvm::raw_ostream &OutBC,
+                    const SnapshotInput<VendorTypes> &In,
+                    bool UpdateBaseData) const override {
+    const auto &GlobalVars = In.GlobalVars;
+    auto &DeviceMemory = In.DeviceMemory;
+
+    size_t TotalGlobals = GlobalVars.size();
+    util::writeScalar(OutBC, TotalGlobals);
+    for (const auto &[VarName, GV] : GlobalVars) {
+      auto BaseIt = PrologueGlobals->find(VarName);
+      if (BaseIt == PrologueGlobals->end())
+        LOG_FATAL("Cannot diff global missing from prologue: " + VarName);
+      if (BaseIt->second.size() != GV.VarSize)
+        LOG_FATAL("Cannot diff global with size mismatch: " + VarName);
+
+      std::vector<uint8_t> Current(GV.VarSize);
+      auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+          DeviceTraits<VendorTypes>::DeviceCopy(
+              Current.data(), const_cast<void *>(GV.DevAddr), GV.VarSize,
+              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
+      if (DEC)
+        LOG_FATAL("Copying from device to host for global diff failed\n");
+
+      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
+          .write(OutBC);
+      size_t NumRanges = countChangedRanges(BaseIt->second, Current);
+      util::writeScalar(OutBC, NumRanges);
+      writeChangedRanges(OutBC, BaseIt->second, Current, 0);
+    }
+
+    size_t TotalBlobs = DeviceMemory.size();
+    util::writeScalar(OutBC, TotalBlobs);
+    for (auto &[Ptr, Blob] : DeviceMemory) {
+      BlobHeader{Blob.getActualSize(), Blob.getSize(), Blob.getBlobAddr()}
+          .write(OutBC);
+      auto MD = Blob.getMetadata();
+      mneme::metadata::serialize(OutBC, MD);
+
+      writeCountAndWriteChangedRanges(OutBC, Blob, UpdateBaseData);
+    }
+  }
+
+private:
+  static constexpr size_t DiffChunkSize = 1 << 20;
+
+  static size_t countChangedRanges(llvm::ArrayRef<uint8_t> Base,
+                                   llvm::ArrayRef<uint8_t> Current) {
+    if (Base.size() != Current.size())
+      LOG_FATAL("Cannot diff buffers with different sizes");
+
+    // Count the number of contiguous ranges that have changed between Base and
+    // Current. We want to write out the number of ranges so that the reader
+    // can know how many ranges to read.
+    size_t Count = 0;
+    bool InRange = false;
+    for (size_t I = 0; I < Base.size(); ++I) {
+      if (Base[I] != Current[I]) {
+        if (!InRange) {
+          Count++;
+          InRange = true;
+        }
+      } else {
+        InRange = false;
+      }
+    }
+    return Count;
+  }
+
+  static size_t
+  writeChangedRanges(llvm::raw_ostream &OS, llvm::ArrayRef<uint8_t> Base,
+                     llvm::ArrayRef<uint8_t> Current, size_t BaseOffset,
+                     llvm::MutableArrayRef<uint8_t> UpdateBase = {}) {
+    if (Base.size() != Current.size())
+      LOG_FATAL("Cannot diff buffers with different sizes");
+    if (!UpdateBase.empty() && UpdateBase.size() != Base.size())
+      LOG_FATAL("Cannot update diff base with mismatched buffer size");
+
+    // Write out the contiguous ranges that have changed between Base
+    // and Current.
+    size_t Count = 0;
+    size_t I = 0;
+    while (I < Base.size()) {
+      while (I < Base.size() && Base[I] == Current[I])
+        ++I;
+      if (I == Base.size())
+        break;
+
+      size_t Start = I;
+      while (I < Base.size() && Base[I] != Current[I])
+        ++I;
+
+      size_t Offset = BaseOffset + Start;
+      size_t Len = I - Start;
+      util::writeScalar(OS, Offset);
+      util::writeScalar(OS, Len);
+      util::writeBytes(OS, Current.slice(Start, Len));
+      if (!UpdateBase.empty())
+        std::memcpy(UpdateBase.data() + Start, Current.data() + Start, Len);
+      ++Count;
+    }
+    return Count;
+  }
+
+  static void
+  writeCountAndWriteChangedRanges(llvm::raw_ostream &OS,
+                                  MnemeMemoryBlob<VendorTypes> &Blob,
+                                  bool UpdateBaseData = true) {
+    auto Size = Blob.getSize();
+
+    // early exit
+    if (Size == 0) {
+      size_t NumRanges = 0;
+      util::writeScalar(OS, NumRanges);
+      return;
+    }
+
+    std::unique_ptr<uint8_t[]> Scratch(new uint8_t[DiffChunkSize]);
+    llvm::SmallVector<char, 0> DiffBytes;
+    llvm::raw_svector_ostream DiffOS(DiffBytes);
+    auto *Base = Blob.getHostData().get();
+    auto *DevAddr = static_cast<uint8_t *>(Blob.getBlobAddr());
+    size_t NumRanges = 0;
+
+    for (size_t Offset = 0; Offset < Size; Offset += DiffChunkSize) {
+      size_t ChunkSize = std::min(DiffChunkSize, Size - Offset);
+      auto EC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+          DeviceTraits<VendorTypes>::DeviceCopy(
+              Scratch.get(), DevAddr + Offset, ChunkSize,
+              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
+      if (EC)
+        LOG_FATAL("Error in copying data from device when writing diff\n"
+                  "Device Error Msg: " +
+                  EC.value() + "\n");
+
+      llvm::ArrayRef<uint8_t> ChunkBase(Base + Offset, ChunkSize);
+      llvm::ArrayRef<uint8_t> ChunkCurrent(Scratch.get(), ChunkSize);
+      if (UpdateBaseData) {
+        llvm::MutableArrayRef<uint8_t> UpdateBase(Base + Offset, ChunkSize);
+        NumRanges += writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset,
+                                        UpdateBase);
+      } else {
+        NumRanges +=
+            writeChangedRanges(DiffOS, ChunkBase, ChunkCurrent, Offset);
+      }
+    }
+
+    util::writeScalar(OS, NumRanges);
+    util::writeBytes(OS, llvm::StringRef(DiffBytes.data(), DiffBytes.size()));
+  }
+
+  std::shared_ptr<const GlobalSnapshotData> PrologueGlobals;
+};
+
+// Writes whichever of bytes or diff is smaller for this input.
+template <DeviceVendors VendorTypes>
+class BestWriter : public SnapshotWriter<VendorTypes> {
+public:
+  explicit BestWriter(std::shared_ptr<const GlobalSnapshotData> PrologueGlobals)
+      : Diff(std::move(PrologueGlobals)) {}
+
+  std::filesystem::path
+  write(const std::filesystem::path &Filename,
+        const SnapshotInput<VendorTypes> &In) const override {
+    size_t DiffSize = Diff.measure(In);
+    size_t BytesSize = Bytes.measure(In);
+
+    if (DiffSize <= BytesSize)
+      return Diff.write(Filename, In);
+
+    return Bytes.write(Filename, In);
+  }
+
+  size_t measure(const SnapshotInput<VendorTypes> &In) const override {
+    return std::min(Diff.measure(In), Bytes.measure(In));
+  }
+
+private:
+  BytesWriter<VendorTypes> Bytes;
+  DiffWriter<VendorTypes> Diff;
+};
+
+// The only place EpilogueSnapshotType is consumed.
+template <DeviceVendors VendorTypes>
+std::unique_ptr<SnapshotWriter<VendorTypes>>
+makeEpilogueWriter(EpilogueSnapshotType Type,
+                   std::shared_ptr<const GlobalSnapshotData> PrologueGlobals) {
+  switch (Type) {
+  case EpilogueSnapshotType::Bytes:
+    return std::make_unique<BytesWriter<VendorTypes>>();
+  case EpilogueSnapshotType::Diff:
+    return std::make_unique<DiffWriter<VendorTypes>>(
+        std::move(PrologueGlobals));
+  case EpilogueSnapshotType::Best:
+    return std::make_unique<BestWriter<VendorTypes>>(
+        std::move(PrologueGlobals));
+  }
+
+  LOG_FATAL("Unknown Mneme epilogue snapshot type");
 }
 
 } // namespace mneme

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -144,8 +144,8 @@ public:
         PayloadOffset(PayloadOffset) {}
   virtual ~SnapshotReader() = default;
 
-  // True if read() never consults Base.
-  virtual bool isSelfContained() const = 0;
+  // True if read() needs a base snapshot to reconstruct the state.
+  virtual bool requiresBaseSnapshot() const = 0;
 
   virtual Snapshot<VendorTypes>
   read(const std::string &KernelName,
@@ -181,7 +181,7 @@ class BytesReaderV0 : public SnapshotReader<VendorTypes> {
 public:
   using SnapshotReader<VendorTypes>::SnapshotReader;
 
-  bool isSelfContained() const override { return true; }
+  bool requiresBaseSnapshot() const override { return false; }
 
   Snapshot<VendorTypes>
   read(const std::string &KernelName,
@@ -235,7 +235,7 @@ class DiffReaderV1 : public SnapshotReader<VendorTypes> {
 public:
   using SnapshotReader<VendorTypes>::SnapshotReader;
 
-  bool isSelfContained() const override { return false; }
+  bool requiresBaseSnapshot() const override { return true; }
 
   Snapshot<VendorTypes>
   read(const std::string &KernelName,
@@ -387,9 +387,9 @@ BaseSnapshotSource<VendorTypes>::load(const std::string &KernelName) const {
     LOG_FATAL("No base snapshot was provided");
 
   auto Reader = SnapshotFormatRegistry<VendorTypes>::open(Filename);
-  if (!Reader->isSelfContained())
+  if (Reader->requiresBaseSnapshot())
     LOG_FATAL("Snapshot " + Filename +
-              " cannot be used as a base because it is not self-contained");
+              " cannot be used as a base because it itself requires a base");
 
   return Reader->read(KernelName, BaseSnapshotSource<VendorTypes>());
 }

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -1,0 +1,394 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include "mneme/DeviceTraits.hpp"
+#include "mneme/MnemeKernelInfo.hpp"
+#include "mneme/MnemeLogger.hpp"
+#include "mneme/MnemeMemory.hpp"
+#include "mneme/MnemeSnapshotRecords.hpp"
+#include "mneme/MnemeUtils.hpp"
+
+namespace mneme {
+
+struct ReplayGlobalVar {
+  void *HostAddr;
+  void *DevAddr;
+  uint64_t VarSize;
+  ReplayGlobalVar(void *DevAddr, uint64_t VarSize)
+      : HostAddr(new uint8_t[VarSize]), DevAddr(DevAddr), VarSize(VarSize) {}
+  ReplayGlobalVar(void *HostAddr, void *DevAddr, uint64_t VarSize)
+      : HostAddr(HostAddr), DevAddr(DevAddr), VarSize(VarSize) {}
+  ReplayGlobalVar() = delete;
+  ~ReplayGlobalVar() {
+    if (HostAddr)
+      delete[] static_cast<uint8_t *>(HostAddr);
+  }
+
+  ReplayGlobalVar(const ReplayGlobalVar &) = delete;
+  ReplayGlobalVar &operator=(const ReplayGlobalVar &) = delete;
+
+  ReplayGlobalVar(ReplayGlobalVar &&Other)
+      : HostAddr(Other.HostAddr), DevAddr(Other.DevAddr),
+        VarSize(Other.VarSize) {
+    Other.HostAddr = nullptr;
+  }
+
+  ReplayGlobalVar &operator=(ReplayGlobalVar &&Other) {
+    if (this != &Other) {
+      this->HostAddr = Other.HostAddr;
+      this->DevAddr = Other.DevAddr;
+      this->VarSize = Other.VarSize;
+      Other.HostAddr = nullptr;
+    }
+    return *this;
+  }
+};
+
+// The in-memory contents of a snapshot, as produced by the snapshot readers
+// and consumed by the replay memory state constructors.
+template <DeviceVendors VendorTypes> struct Snapshot {
+  std::shared_ptr<KernelInfo> KInfo;
+  std::unordered_map<std::string, ReplayGlobalVar> GlobalVars;
+  llvm::DenseMap<void *, MnemeMemoryBlob<VendorTypes>> DeviceMemory;
+};
+
+inline std::pair<std::string, ReplayGlobalVar>
+readGlobalVarRecord(const char *&Buffer) {
+  GlobalVarHeader Header = GlobalVarHeader::read(Buffer);
+  ReplayGlobalVar RGV(Header.DevAddr, Header.Size);
+  std::memcpy(const_cast<void *>(RGV.HostAddr), Buffer, Header.Size);
+  Buffer += Header.Size;
+  LOG_DEBUG("Loaded from buffer Global, Name:{}, VarSize:{}, RecoredAddr:{}",
+            Header.Name, Header.Size, Header.DevAddr);
+  return std::pair<std::string, ReplayGlobalVar>(std::move(Header.Name),
+                                                 std::move(RGV));
+}
+
+// A host copy of every global a prologue captured, keyed by variable name. The
+// diff writer uses it as the base its ranges are computed against.
+using GlobalSnapshotData =
+    std::unordered_map<std::string, std::vector<uint8_t>>;
+
+enum class SnapshotKind : uint32_t { Bytes = 1, Diff = 2 };
+
+// The only code in Mneme that knows a snapshot magic string.
+struct SnapshotHeader {
+  SnapshotKind Kind;
+  uint32_t Version;
+
+  static constexpr char Magic[8] = {'M', 'N', 'E', 'M', 'E', 'S', 'N', 'P'};
+  static constexpr size_t Size = 16;
+
+  // Returns the header and the number of prefix bytes the payload follows.
+  static std::pair<SnapshotHeader, size_t> parse(llvm::StringRef Buffer);
+  void write(llvm::raw_ostream &OS) const;
+
+private:
+  // Diff files written before the container header carried this instead.
+  static constexpr char LegacyDiffMagic[] = "MNEME_DIFF_V1";
+  static constexpr size_t LegacyDiffMagicSize = sizeof(LegacyDiffMagic) - 1;
+};
+
+inline std::pair<SnapshotHeader, size_t>
+SnapshotHeader::parse(llvm::StringRef Buffer) {
+  if (Buffer.size() >= Size && Buffer.take_front(sizeof(Magic)) ==
+                                   llvm::StringRef(Magic, sizeof(Magic))) {
+    SnapshotKind Kind;
+    uint32_t Version;
+    std::memcpy(&Kind, Buffer.data() + sizeof(Magic), sizeof(Kind));
+    std::memcpy(&Version, Buffer.data() + sizeof(Magic) + sizeof(Kind),
+                sizeof(Version));
+    return {SnapshotHeader{Kind, Version}, Size};
+  }
+
+  if (Buffer.size() >= LegacyDiffMagicSize &&
+      Buffer.take_front(LegacyDiffMagicSize) ==
+          llvm::StringRef(LegacyDiffMagic, LegacyDiffMagicSize))
+    return {SnapshotHeader{SnapshotKind::Diff, 1}, LegacyDiffMagicSize};
+
+  return {SnapshotHeader{SnapshotKind::Bytes, 0}, 0};
+}
+
+// Still emits the legacy prefixes so files written here stay readable by older
+// Mneme builds; the container header replaces this in a later change.
+inline void SnapshotHeader::write(llvm::raw_ostream &OS) const {
+  if (Kind == SnapshotKind::Diff)
+    util::writeBytes(OS, llvm::StringRef(LegacyDiffMagic, LegacyDiffMagicSize));
+}
+
+template <DeviceVendors VendorTypes> class BaseSnapshotSource;
+
+// An opened snapshot file. Each subclass decodes one on-disk layout.
+template <DeviceVendors VendorTypes> class SnapshotReader {
+public:
+  SnapshotReader(std::string Filename,
+                 std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                 size_t PayloadOffset)
+      : Filename(std::move(Filename)), Buffer(std::move(Buffer)),
+        PayloadOffset(PayloadOffset) {}
+  virtual ~SnapshotReader() = default;
+
+  // True if read() never consults Base.
+  virtual bool isSelfContained() const = 0;
+
+  virtual Snapshot<VendorTypes>
+  read(const std::string &KernelName,
+       const BaseSnapshotSource<VendorTypes> &Base) const = 0;
+
+protected:
+  const char *payload() const {
+    return Buffer->getBufferStart() + PayloadOffset;
+  }
+
+  std::string Filename;
+  std::unique_ptr<llvm::MemoryBuffer> Buffer;
+  size_t PayloadOffset;
+};
+
+// Loads a base prologue snapshot on demand for readers that need one.
+template <DeviceVendors VendorTypes> class BaseSnapshotSource {
+public:
+  // An empty Filename means no base is available.
+  explicit BaseSnapshotSource(std::string Filename = "")
+      : Filename(std::move(Filename)) {}
+
+  bool empty() const { return Filename.empty(); }
+
+  Snapshot<VendorTypes> load(const std::string &KernelName) const;
+
+private:
+  std::string Filename;
+};
+
+template <DeviceVendors VendorTypes>
+class BytesReaderV0 : public SnapshotReader<VendorTypes> {
+public:
+  using SnapshotReader<VendorTypes>::SnapshotReader;
+
+  bool isSelfContained() const override { return true; }
+
+  Snapshot<VendorTypes>
+  read(const std::string &KernelName,
+       const BaseSnapshotSource<VendorTypes> &) const override {
+    Snapshot<VendorTypes> Snap;
+    // KernelInfo's constructor takes a non-const std::string &, so name it with
+    // a mutable local.
+    std::string Name = KernelName;
+    Snap.KInfo = std::make_shared<KernelInfo>(Name);
+
+    auto &GlobalVars = Snap.GlobalVars;
+    auto &DeviceMemory = Snap.DeviceMemory;
+    auto &KInfo = Snap.KInfo;
+
+    auto *Start = this->payload();
+    auto *CurrentPtr = Start;
+    size_t TotalGlobals = util::extractScalar<size_t>(CurrentPtr);
+    LOG_DEBUG("Snapshot contains {} Globals at location {}", TotalGlobals,
+              (uintptr_t)CurrentPtr - (uintptr_t)Start);
+    for (auto I = 0; I < TotalGlobals; I++) {
+      auto [Name, RGV] = readGlobalVarRecord(CurrentPtr);
+      GlobalVars.try_emplace(Name, std::move(RGV));
+    }
+
+    auto TotalMemBlobs = util::extractScalar<size_t>(CurrentPtr);
+
+    LOG_DEBUG("Snapshot contains {} Memory Blobs starting at location {}",
+              TotalMemBlobs, (uintptr_t)CurrentPtr - (uintptr_t)Start);
+
+    for (auto M = 0; M < TotalMemBlobs; M++) {
+      DeviceMemory.insert(MnemeMemoryBlob<VendorTypes>::fromBuffer(CurrentPtr));
+    }
+
+    // Get kernel arguments.
+    auto TotalArguments = util::extractScalar<size_t>(CurrentPtr);
+    LOG_DEBUG("Snapshot contains {} total arguments starting at location {}",
+              TotalArguments, (uintptr_t)CurrentPtr - (uintptr_t)Start);
+    KInfo->KernelArgSizes.resize(TotalArguments);
+    KInfo->ArgData.resize(TotalArguments);
+    for (auto A = 0; A < TotalArguments; A++) {
+      KInfo->KernelArgSizes[A] = util::extractScalar<size_t>(CurrentPtr);
+      KInfo->setArgData(CurrentPtr, A);
+    }
+
+    return Snap;
+  }
+};
+
+template <DeviceVendors VendorTypes>
+class DiffReaderV1 : public SnapshotReader<VendorTypes> {
+public:
+  using SnapshotReader<VendorTypes>::SnapshotReader;
+
+  bool isSelfContained() const override { return false; }
+
+  Snapshot<VendorTypes>
+  read(const std::string &KernelName,
+       const BaseSnapshotSource<VendorTypes> &Base) const override {
+    if (Base.empty())
+      LOG_FATAL("Mneme diff snapshot " + this->Filename +
+                " requires a base prologue snapshot");
+
+    // A diff stores only changed ranges, so reconstruct the full base prologue
+    // first and then overlay the diff onto it.
+    Snapshot<VendorTypes> Snap = Base.load(KernelName);
+    const std::string &Filename = this->Filename;
+    auto &GlobalVars = Snap.GlobalVars;
+    auto &DeviceMemory = Snap.DeviceMemory;
+
+    auto *CurrentPtr = this->payload();
+    size_t TotalGlobals = util::extractScalar<size_t>(CurrentPtr);
+    if (TotalGlobals != GlobalVars.size())
+      LOG_FATAL("Mneme diff " + Filename +
+                " does not match prologue global count");
+
+    for (size_t I = 0; I < TotalGlobals; ++I) {
+      GlobalVarHeader GVH = GlobalVarHeader::read(CurrentPtr);
+      size_t NumRanges = util::extractScalar<size_t>(CurrentPtr);
+
+      auto It = GlobalVars.find(GVH.Name);
+      if (It == GlobalVars.end())
+        LOG_FATAL("Mneme diff references global missing from prologue: " +
+                  GVH.Name);
+      if (It->second.VarSize != GVH.Size)
+        LOG_FATAL("Mneme diff global size mismatch for: " + GVH.Name);
+      It->second.DevAddr = GVH.DevAddr;
+      applyDiffRanges(
+          CurrentPtr,
+          llvm::MutableArrayRef<uint8_t>(
+              static_cast<uint8_t *>(It->second.HostAddr), It->second.VarSize),
+          NumRanges);
+    }
+
+    size_t TotalMemBlobs = util::extractScalar<size_t>(CurrentPtr);
+    if (TotalMemBlobs != DeviceMemory.size())
+      LOG_FATAL("Mneme diff " + Filename +
+                " does not match prologue memory blob count");
+
+    for (size_t I = 0; I < TotalMemBlobs; ++I) {
+      BlobHeader BH = BlobHeader::read(CurrentPtr);
+      auto MD = metadata::fromBuffer(CurrentPtr);
+      size_t NumRanges = util::extractScalar<size_t>(CurrentPtr);
+
+      auto It = DeviceMemory.find(BH.DevAddr);
+      if (It == DeviceMemory.end())
+        LOG_FATAL("Mneme diff references device allocation missing from "
+                  "prologue");
+      auto &Blob = It->second;
+      if (Blob.getActualSize() != BH.ActualSize || Blob.getSize() != BH.Size)
+        LOG_FATAL("Mneme diff memory blob size mismatch");
+      Blob.setMetadata(MD);
+      applyDiffRanges(CurrentPtr,
+                      llvm::MutableArrayRef<uint8_t>(Blob.getHostData().get(),
+                                                     Blob.getSize()),
+                      NumRanges);
+    }
+
+    return Snap;
+  }
+
+private:
+  static void applyDiffRanges(const char *&Buffer,
+                              llvm::MutableArrayRef<uint8_t> Target,
+                              size_t NumRanges) {
+    for (size_t R = 0; R < NumRanges; ++R) {
+      size_t Offset = util::extractScalar<size_t>(Buffer);
+      size_t Size = util::extractScalar<size_t>(Buffer);
+      if (Offset > Target.size() || Size > Target.size() - Offset)
+        LOG_FATAL("Malformed Mneme diff range: offset " +
+                  std::to_string(Offset) + " size " + std::to_string(Size) +
+                  " exceeds target size " + std::to_string(Target.size()));
+      std::memcpy(Target.data() + Offset, Buffer, Size);
+      Buffer += Size;
+    }
+  }
+};
+
+// Every layout Mneme has ever written needs a row here.
+template <DeviceVendors VendorTypes> class SnapshotFormatRegistry {
+public:
+  static std::unique_ptr<SnapshotReader<VendorTypes>>
+  open(const std::string &Filename) {
+    LOG_DEBUG("Opening snapshot file {}", Filename);
+    auto Buffer = openSnapshotFile(Filename);
+    auto [Header, PayloadOffset] = SnapshotHeader::parse(Buffer->getBuffer());
+
+    size_t Count = 0;
+    const Entry *Table = table(Count);
+    for (size_t I = 0; I < Count; ++I)
+      if (Table[I].Kind == Header.Kind && Table[I].Version == Header.Version)
+        return Table[I].Make(Filename, std::move(Buffer), PayloadOffset);
+
+    LOG_FATAL("Unsupported Mneme snapshot format in " + Filename + ": kind " +
+              std::to_string(static_cast<uint32_t>(Header.Kind)) + " version " +
+              std::to_string(Header.Version));
+  }
+
+private:
+  using Factory = std::unique_ptr<SnapshotReader<VendorTypes>> (*)(
+      std::string, std::unique_ptr<llvm::MemoryBuffer>, size_t);
+
+  struct Entry {
+    SnapshotKind Kind;
+    uint32_t Version;
+    Factory Make;
+  };
+
+  template <typename ReaderT>
+  static std::unique_ptr<SnapshotReader<VendorTypes>>
+  make(std::string Filename, std::unique_ptr<llvm::MemoryBuffer> Buffer,
+       size_t PayloadOffset) {
+    return std::make_unique<ReaderT>(std::move(Filename), std::move(Buffer),
+                                     PayloadOffset);
+  }
+
+  static const Entry *table(size_t &Count) {
+    static const Entry Table[] = {
+        {SnapshotKind::Bytes, 0, &make<BytesReaderV0<VendorTypes>>},
+        {SnapshotKind::Diff, 1, &make<DiffReaderV1<VendorTypes>>},
+    };
+    Count = sizeof(Table) / sizeof(Table[0]);
+    return Table;
+  }
+
+  static std::unique_ptr<llvm::MemoryBuffer>
+  openSnapshotFile(const std::string &Filename) {
+    if (!std::filesystem::exists(Filename))
+      LOG_FATAL("Mneme Snapshot file does not exist");
+
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrErr =
+        llvm::MemoryBuffer::getFile(Filename);
+    if (std::error_code EC = BufferOrErr.getError())
+      LOG_FATAL("Error when opening file " + EC.message());
+
+    return std::move(BufferOrErr.get());
+  }
+};
+
+template <DeviceVendors VendorTypes>
+Snapshot<VendorTypes>
+BaseSnapshotSource<VendorTypes>::load(const std::string &KernelName) const {
+  if (empty())
+    LOG_FATAL("No base snapshot was provided");
+
+  auto Reader = SnapshotFormatRegistry<VendorTypes>::open(Filename);
+  if (!Reader->isSelfContained())
+    LOG_FATAL("Snapshot " + Filename +
+              " cannot be used as a base because it is not self-contained");
+
+  return Reader->read(KernelName, BaseSnapshotSource<VendorTypes>());
+}
+
+} // namespace mneme

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -107,8 +107,8 @@ private:
 
 inline std::pair<SnapshotHeader, size_t>
 SnapshotHeader::parse(llvm::StringRef Buffer) {
-  if (Buffer.size() >= Size && Buffer.take_front(sizeof(Magic)) ==
-                                   llvm::StringRef(Magic, sizeof(Magic))) {
+  if (Buffer.size() >= Size &&
+      Buffer.starts_with(llvm::StringRef(Magic, sizeof(Magic)))) {
     SnapshotKind Kind;
     uint32_t Version;
     std::memcpy(&Kind, Buffer.data() + sizeof(Magic), sizeof(Kind));
@@ -117,9 +117,7 @@ SnapshotHeader::parse(llvm::StringRef Buffer) {
     return {SnapshotHeader{Kind, Version}, Size};
   }
 
-  if (Buffer.size() >= LegacyDiffMagicSize &&
-      Buffer.take_front(LegacyDiffMagicSize) ==
-          llvm::StringRef(LegacyDiffMagic, LegacyDiffMagicSize))
+  if (Buffer.starts_with(llvm::StringRef(LegacyDiffMagic, LegacyDiffMagicSize)))
     return {SnapshotHeader{SnapshotKind::Diff, 1}, LegacyDiffMagicSize};
 
   return {SnapshotHeader{SnapshotKind::Bytes, 0}, 0};
@@ -250,9 +248,7 @@ public:
 
     auto *CurrentPtr = this->payload();
     size_t TotalGlobals = util::extractScalar<size_t>(CurrentPtr);
-    if (TotalGlobals != GlobalVars.size())
-      LOG_FATAL("Mneme diff " + Filename +
-                " does not match prologue global count");
+    expectCount(TotalGlobals, GlobalVars.size(), Filename, "global");
 
     for (size_t I = 0; I < TotalGlobals; ++I) {
       GlobalVarHeader GVH = GlobalVarHeader::read(CurrentPtr);
@@ -273,9 +269,7 @@ public:
     }
 
     size_t TotalMemBlobs = util::extractScalar<size_t>(CurrentPtr);
-    if (TotalMemBlobs != DeviceMemory.size())
-      LOG_FATAL("Mneme diff " + Filename +
-                " does not match prologue memory blob count");
+    expectCount(TotalMemBlobs, DeviceMemory.size(), Filename, "memory blob");
 
     for (size_t I = 0; I < TotalMemBlobs; ++I) {
       BlobHeader BH = BlobHeader::read(CurrentPtr);
@@ -300,6 +294,13 @@ public:
   }
 
 private:
+  static void expectCount(size_t Actual, size_t Expected,
+                          const std::string &Filename, const char *What) {
+    if (Actual != Expected)
+      LOG_FATAL("Mneme diff " + Filename + " does not match prologue " + What +
+                " count");
+  }
+
   static void applyDiffRanges(const char *&Buffer,
                               llvm::MutableArrayRef<uint8_t> Target,
                               size_t NumRanges) {
@@ -399,6 +400,28 @@ template <DeviceVendors VendorTypes> struct SnapshotInput {
   typename DeviceTraits<VendorTypes>::DeviceStream_t Stream;
 };
 
+// The on-disk record prefix describing a captured global variable.
+inline GlobalVarHeader
+globalVarHeader(const std::string &Name,
+                const proteus::runtime::GlobalMetadata &GV) {
+  return GlobalVarHeader{Name, GV.VarSize, const_cast<void *>(GV.DevAddr)};
+}
+
+// The global's current contents, copied off the device.
+template <DeviceVendors VendorTypes>
+std::vector<uint8_t>
+readGlobalFromDevice(const proteus::runtime::GlobalMetadata &GV) {
+  std::vector<uint8_t> HostData(GV.VarSize);
+  auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
+      DeviceTraits<VendorTypes>::DeviceCopy(
+          HostData.data(), const_cast<void *>(GV.DevAddr), GV.VarSize,
+          DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
+  if (DEC)
+    LOG_FATAL("Copying from device to host for global variable failed");
+
+  return HostData;
+}
+
 // Which writer is used is a config choice, not a property of any file.
 template <DeviceVendors VendorTypes> class SnapshotWriter {
 public:
@@ -489,9 +512,7 @@ public:
 
     Size += sizeof(size_t);
     for (const auto &[VarName, GV] : In.GlobalVars) {
-      Size +=
-          GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
-              .serializedSize();
+      Size += globalVarHeader(VarName, GV).serializedSize();
       Size += GV.VarSize;
     }
 
@@ -531,25 +552,12 @@ protected:
               TotalGlobals, OutBC.tell());
 
     for (const auto &[VarName, GV] : GlobalVars) {
-      std::cout << "Reading " << VarName << " " << GV.HostAddr << " "
-                << GV.DevAddr << " " << GV.VarSize << "\n";
-      std::unique_ptr<uint8_t[]> HostData(new uint8_t[GV.VarSize]);
-      auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-          DeviceTraits<VendorTypes>::DeviceCopy(
-              HostData.get(), const_cast<void *>(GV.DevAddr), GV.VarSize,
-              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
-      if (DEC) {
-        std::cout << DEC.value() << "\n";
-        LOG_FATAL("Copying from device to host for global variables failed\n");
-      }
+      std::vector<uint8_t> HostData = readGlobalFromDevice<VendorTypes>(GV);
 
-      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
-          .write(OutBC);
-      OutBC << llvm::StringRef(reinterpret_cast<const char *>(HostData.get()),
-                               GV.VarSize);
+      globalVarHeader(VarName, GV).write(OutBC);
+      util::writeBytes(OutBC, llvm::ArrayRef<uint8_t>(HostData));
       if (CaptureGlobals)
-        (*CaptureGlobals)[VarName] =
-            std::vector<uint8_t>(HostData.get(), HostData.get() + GV.VarSize);
+        (*CaptureGlobals)[VarName] = std::move(HostData);
     }
 
     size_t TotalBlobs = DeviceMemory.size();
@@ -612,19 +620,14 @@ protected:
       if (BaseIt->second.size() != GV.VarSize)
         LOG_FATAL("Cannot diff global with size mismatch: " + VarName);
 
-      std::vector<uint8_t> Current(GV.VarSize);
-      auto DEC = DeviceTraits<VendorTypes>::DeviceErrorCheck(
-          DeviceTraits<VendorTypes>::DeviceCopy(
-              Current.data(), const_cast<void *>(GV.DevAddr), GV.VarSize,
-              DeviceTraits<VendorTypes>::MemcpyDeviceToHostKind()));
-      if (DEC)
-        LOG_FATAL("Copying from device to host for global diff failed\n");
+      std::vector<uint8_t> Current = readGlobalFromDevice<VendorTypes>(GV);
 
-      GlobalVarHeader{VarName, GV.VarSize, const_cast<void *>(GV.DevAddr)}
-          .write(OutBC);
-      size_t NumRanges = countChangedRanges(BaseIt->second, Current);
-      util::writeScalar(OutBC, NumRanges);
-      writeChangedRanges(OutBC, BaseIt->second, Current, 0);
+      globalVarHeader(VarName, GV).write(OutBC);
+
+      llvm::SmallVector<char, 0> DiffBytes;
+      llvm::raw_svector_ostream DiffOS(DiffBytes);
+      size_t NumRanges = writeChangedRanges(DiffOS, BaseIt->second, Current, 0);
+      emitRanges(OutBC, NumRanges, DiffBytes);
     }
 
     size_t TotalBlobs = DeviceMemory.size();
@@ -642,27 +645,12 @@ protected:
 private:
   static constexpr size_t DiffChunkSize = 1 << 20;
 
-  static size_t countChangedRanges(llvm::ArrayRef<uint8_t> Base,
-                                   llvm::ArrayRef<uint8_t> Current) {
-    if (Base.size() != Current.size())
-      LOG_FATAL("Cannot diff buffers with different sizes");
-
-    // Count the number of contiguous ranges that have changed between Base and
-    // Current. We want to write out the number of ranges so that the reader
-    // can know how many ranges to read.
-    size_t Count = 0;
-    bool InRange = false;
-    for (size_t I = 0; I < Base.size(); ++I) {
-      if (Base[I] != Current[I]) {
-        if (!InRange) {
-          Count++;
-          InRange = true;
-        }
-      } else {
-        InRange = false;
-      }
-    }
-    return Count;
+  // The reader needs the range count before the ranges themselves, so the
+  // ranges are scanned into a scratch buffer first.
+  static void emitRanges(llvm::raw_ostream &OS, size_t NumRanges,
+                         const llvm::SmallVectorImpl<char> &DiffBytes) {
+    util::writeScalar(OS, NumRanges);
+    util::writeBytes(OS, llvm::StringRef(DiffBytes.data(), DiffBytes.size()));
   }
 
   static size_t
@@ -743,8 +731,7 @@ private:
       }
     }
 
-    util::writeScalar(OS, NumRanges);
-    util::writeBytes(OS, llvm::StringRef(DiffBytes.data(), DiffBytes.size()));
+    emitRanges(OS, NumRanges, DiffBytes);
   }
 
   std::shared_ptr<const GlobalSnapshotData> PrologueGlobals;

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -125,11 +125,11 @@ SnapshotHeader::parse(llvm::StringRef Buffer) {
   return {SnapshotHeader{SnapshotKind::Bytes, 0}, 0};
 }
 
-// Still emits the legacy prefixes so files written here stay readable by older
-// Mneme builds; the container header replaces this in a later change.
+// Bytes files carry the prefix too so that they can be versioned.
 inline void SnapshotHeader::write(llvm::raw_ostream &OS) const {
-  if (Kind == SnapshotKind::Diff)
-    util::writeBytes(OS, llvm::StringRef(LegacyDiffMagic, LegacyDiffMagicSize));
+  util::writeBytes(OS, llvm::StringRef(Magic, sizeof(Magic)));
+  util::writeScalar(OS, Kind);
+  util::writeScalar(OS, Version);
 }
 
 template <DeviceVendors VendorTypes> class BaseSnapshotSource;

--- a/include/mneme/MnemeSnapshotFormat.hpp
+++ b/include/mneme/MnemeSnapshotFormat.hpp
@@ -179,6 +179,8 @@ class BytesReaderV0 : public SnapshotReader<VendorTypes> {
 public:
   using SnapshotReader<VendorTypes>::SnapshotReader;
 
+  static constexpr SnapshotHeader Layout{SnapshotKind::Bytes, 0};
+
   bool requiresBaseSnapshot() const override { return false; }
 
   Snapshot<VendorTypes>
@@ -229,6 +231,8 @@ template <DeviceVendors VendorTypes>
 class DiffReaderV1 : public SnapshotReader<VendorTypes> {
 public:
   using SnapshotReader<VendorTypes>::SnapshotReader;
+
+  static constexpr SnapshotHeader Layout{SnapshotKind::Diff, 1};
 
   bool requiresBaseSnapshot() const override { return true; }
 
@@ -317,7 +321,9 @@ private:
   }
 };
 
-// Every layout Mneme has ever written needs a row here.
+// Every layout Mneme has ever written needs a row here. A reader owns its
+// (kind, version) pair through its Layout member; the writer that produces
+// the current layout returns the same member from header().
 template <DeviceVendors VendorTypes> class SnapshotFormatRegistry {
 public:
   static std::unique_ptr<SnapshotReader<VendorTypes>>
@@ -355,10 +361,14 @@ private:
                                      PayloadOffset);
   }
 
+  template <typename ReaderT> static constexpr Entry entry() {
+    return {ReaderT::Layout.Kind, ReaderT::Layout.Version, &make<ReaderT>};
+  }
+
   static const Entry *table(size_t &Count) {
     static const Entry Table[] = {
-        {SnapshotKind::Bytes, 0, &make<BytesReaderV0<VendorTypes>>},
-        {SnapshotKind::Diff, 1, &make<DiffReaderV1<VendorTypes>>},
+        entry<BytesReaderV0<VendorTypes>>(),
+        entry<DiffReaderV1<VendorTypes>>(),
     };
     Count = sizeof(Table) / sizeof(Table[0]);
     return Table;
@@ -533,7 +543,7 @@ public:
 
 protected:
   SnapshotHeader header() const override {
-    return SnapshotHeader{SnapshotKind::Bytes, 0};
+    return BytesReaderV0<VendorTypes>::Layout;
   }
 
   void writePayload(llvm::raw_ostream &OutBC,
@@ -602,7 +612,7 @@ public:
 
 protected:
   SnapshotHeader header() const override {
-    return SnapshotHeader{SnapshotKind::Diff, 1};
+    return DiffReaderV1<VendorTypes>::Layout;
   }
 
   void writePayload(llvm::raw_ostream &OutBC,

--- a/include/mneme/MnemeSnapshotRecords.hpp
+++ b/include/mneme/MnemeSnapshotRecords.hpp
@@ -1,0 +1,64 @@
+#pragma once
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include "mneme/MnemeLLVMUtils.hpp"
+#include "mneme/MnemeUtils.hpp"
+
+namespace mneme {
+
+// Global-variable record prefix: | Name length | Name | Size | DevAddr |.
+struct GlobalVarHeader {
+  std::string Name;
+  size_t Size;
+  void *DevAddr;
+
+  void write(llvm::raw_ostream &OS) const {
+    util::writeScalar(OS, Name.size());
+    util::writeBytes(OS, llvm::StringRef(Name));
+    util::writeScalar(OS, Size);
+    util::writeScalar(OS, DevAddr);
+  }
+
+  static GlobalVarHeader read(const char *&Buffer) {
+    std::string Name = util::readSizedString(Buffer);
+    size_t Size = util::extractScalar<size_t>(Buffer);
+    void *DevAddr = util::extractScalar<void *>(Buffer);
+    return GlobalVarHeader{std::move(Name), Size, DevAddr};
+  }
+
+  size_t serializedSize() const {
+    return sizeof(size_t) + Name.size() + sizeof(Size) + sizeof(DevAddr);
+  }
+};
+
+// Device-memory blob record prefix: | ActualSize | Size | DevAddr |. Metadata
+// is excluded because the bytes and diff layouts place it differently.
+struct BlobHeader {
+  size_t ActualSize;
+  size_t Size;
+  void *DevAddr;
+
+  void write(llvm::raw_ostream &OS) const {
+    util::writeScalar(OS, ActualSize);
+    util::writeScalar(OS, Size);
+    util::writeScalar(OS, DevAddr);
+  }
+
+  static BlobHeader read(const char *&Buffer) {
+    size_t ActualSize = util::extractScalar<size_t>(Buffer);
+    size_t Size = util::extractScalar<size_t>(Buffer);
+    void *DevAddr = util::extractScalar<void *>(Buffer);
+    return BlobHeader{ActualSize, Size, DevAddr};
+  }
+
+  static constexpr size_t serializedSize() {
+    return 2 * sizeof(size_t) + sizeof(void *);
+  }
+};
+
+} // namespace mneme

--- a/python/mneme/recorded_execution.py
+++ b/python/mneme/recorded_execution.py
@@ -161,8 +161,6 @@ class MemStateRef:
     ):
         if not Path(fn).exists():
             raise RuntimeError(f"Expected snapshot file: {fn} to exist")
-        if snap_type == SnapshotType.EPILOGUE and base_prologue_fn is None:
-            raise RuntimeError("Epilogue snapshots require a base prologue path")
         if base_prologue_fn is not None and not Path(base_prologue_fn).exists():
             raise RuntimeError(
                 f"Expected base prologue file: {base_prologue_fn} to exist"

--- a/python/tests/test_record_annotations.py
+++ b/python/tests/test_record_annotations.py
@@ -13,9 +13,20 @@ NORM_L2 = 2
 NORM_LINF = 3
 
 
+# The container prefix SnapshotHeader writes. Older recordings have none.
+CONTAINER_MAGIC = b"MNEMESNP"
+CONTAINER_SIZE = 16
+
+
+def _payload_offset(data: bytes) -> int:
+    if len(data) >= CONTAINER_SIZE and data[:8] == CONTAINER_MAGIC:
+        return CONTAINER_SIZE
+    return 0
+
+
 def _parse_prologue_blob_metadata(prologue_path: Path):
     data = prologue_path.read_bytes()
-    off = 0
+    off = _payload_offset(data)
 
     def read_u64():
         nonlocal off

--- a/python/tests/test_recorded_execution.py
+++ b/python/tests/test_recorded_execution.py
@@ -34,10 +34,17 @@ def test_memstate_open_initializes_and_loads():
             fake.MnemePy_LoadMemState.assert_called_once_with("STATE")
 
 
-def test_epilogue_memstate_requires_base_prologue():
+def test_epilogue_memstate_without_base_passes_empty_path_to_ffi():
     with patch("mneme.recorded_execution.Path.exists", return_value=True):
-        with pytest.raises(RuntimeError):
-            MemStateRef("snap.epi", "kernelA", SnapshotType.EPILOGUE)
+        with patch("mneme.recorded_execution.ffi.lib") as fake:
+            fake.MnemePy_initializeMemState.return_value = "STATE"
+
+            m = MemStateRef("snap.epi", "kernelA", SnapshotType.EPILOGUE)
+            m.open()
+
+            args, _ = fake.MnemePy_initializeMemState.call_args
+            assert args[2].value == b""
+            assert args[3].value is False
 
 
 def test_epilogue_memstate_passes_base_prologue_to_ffi():

--- a/src/MnemeAnnotationInternal.cpp
+++ b/src/MnemeAnnotationInternal.cpp
@@ -20,6 +20,12 @@ void serialize(llvm::raw_ostream &OS, const Metadata &Md) {
     OS.write(reinterpret_cast<const char *>(Md.tag->c_str()), Size);
 }
 
+size_t serializedSize(const Metadata &Md) {
+  return sizeof(std::underlying_type_t<BuiltinDType>) + sizeof(double) +
+         sizeof(ThresholdKind) + sizeof(Norm) + sizeof(size_t) +
+         (Md.tag ? Md.tag->size() : 0);
+}
+
 Metadata fromBuffer(const char *&Buffer) {
   Metadata Md;
   Md.builtin = util::extractScalar<BuiltinDType>(Buffer);

--- a/tests/record/read-record.py
+++ b/tests/record/read-record.py
@@ -10,6 +10,8 @@ from pathlib import Path
 # Binary .mneme prologue parser
 #
 # On-disk format (all integers little-endian, pointer-sized = 8 bytes):
+#   SnapshotHeader: char[8] "MNEMESNP"; uint32 Kind; uint32 Version (absent in
+#     older recordings)
 #   uint64  TotalGlobals
 #   for each global:
 #     uint64 StrLen; char[StrLen] name; uint64 VarSize; void* DevAddr; char[VarSize] data
@@ -22,11 +24,22 @@ from pathlib import Path
 #   for each arg: uint64 ArgSize; char[ArgSize] data
 # ---------------------------------------------------------------------------
 
+_CONTAINER_MAGIC = b"MNEMESNP"
+_CONTAINER_SIZE = 16
+
+
+def _payload_offset(data):
+    """Byte offset of the payload of a bytes snapshot."""
+    if len(data) >= _CONTAINER_SIZE and data[:8] == _CONTAINER_MAGIC:
+        return _CONTAINER_SIZE
+    return 0
+
+
 def _parse_prologue_metadata(filename):
     """Return a list of Metadata dicts for every blob in a prologue file."""
     with open(filename, "rb") as f:
         data = f.read()
-    off = 0
+    off = _payload_offset(data)
 
     def u64():
         nonlocal off

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -97,10 +97,12 @@ int main(int argc, char **argv) {
   DeviceMemMap.try_emplace((void *)BlobData.first, std::move(Blob));
   std::filesystem::path SnapshotFN("./test.mneme");
 
-  MnemeSnapshot<Vendor>::GlobalSnapshotData PrologueGlobals;
-  MnemeSnapshot<Vendor>::takeMnemeBytesSnapshot(
-      GVars, DeviceMemMap, SnapshotFN, TestKernel->KernelArgSizes, Args, 0,
-      &PrologueGlobals);
+  auto PrologueGlobals = std::make_shared<GlobalSnapshotData>();
+  SnapshotInput<Vendor> In{GVars, DeviceMemMap, TestKernel->KernelArgSizes,
+                           Args, nullptr};
+  BytesWriter<Vendor> PrologueWriter(PrologueGlobals);
+  size_t MeasuredBytes = PrologueWriter.measure(In);
+  PrologueWriter.write(SnapshotFN, In);
 
   auto ReadSnap = SnapshotFormatRegistry<Vendor>::open(SnapshotFN.string())
                       ->read(KernelName, BaseSnapshotSource<Vendor>());
@@ -243,8 +245,9 @@ int main(int argc, char **argv) {
     LOG_FATAL("Could not update device global data");
 
   std::filesystem::path DiffSnapshotFN("./test.epilogue.mneme");
-  MnemeSnapshot<Vendor>::takeMnemeDiffSnapshot(
-      GVars, DeviceMemMap, DiffSnapshotFN, PrologueGlobals, 0);
+  DiffWriter<Vendor> DiffSnapshotWriter(PrologueGlobals);
+  size_t MeasuredDiff = DiffSnapshotWriter.measure(In);
+  DiffSnapshotWriter.write(DiffSnapshotFN, In);
 
   auto DiffSnap =
       SnapshotFormatRegistry<Vendor>::open(DiffSnapshotFN.string())
@@ -330,12 +333,12 @@ int main(int argc, char **argv) {
   };
 
   llvm::SmallVector<size_t> EmptyArgSizes;
+  SnapshotInput<Vendor> InNoArgs{GVars, DeviceMemMap, EmptyArgSizes, nullptr,
+                                 nullptr};
 
   ResetBlobBase();
   std::filesystem::path SparseBestSnapshotFN("./test.best.sparse.mneme");
-  MnemeSnapshot<Vendor>::takeBestMnemeSnapshot(
-      GVars, DeviceMemMap, SparseBestSnapshotFN, EmptyArgSizes, nullptr,
-      PrologueGlobals, 0);
+  BestWriter<Vendor>(PrologueGlobals).write(SparseBestSnapshotFN, InNoArgs);
   auto ValidateBestSparse = [&]() {
     if (SnapshotFormatRegistry<Vendor>::open(SparseBestSnapshotFN.string())
             ->isSelfContained()) {
@@ -384,9 +387,7 @@ int main(int argc, char **argv) {
   ResetBlobBase();
   std::filesystem::path FragmentedBestSnapshotFN(
       "./test.best.fragmented.mneme");
-  MnemeSnapshot<Vendor>::takeBestMnemeSnapshot(
-      GVars, DeviceMemMap, FragmentedBestSnapshotFN, EmptyArgSizes, nullptr,
-      PrologueGlobals, 0);
+  BestWriter<Vendor>(PrologueGlobals).write(FragmentedBestSnapshotFN, InNoArgs);
   auto ValidateBestFragmented = [&]() {
     if (!SnapshotFormatRegistry<Vendor>::open(FragmentedBestSnapshotFN.string())
              ->isSelfContained()) {
@@ -403,6 +404,24 @@ int main(int argc, char **argv) {
       std::cerr
           << "Best fragmented snapshot did not reconstruct epilogue data\n";
       return 128;
+    }
+    return 0;
+  }();
+
+  // "Best" mode decides on measure(), so it must match the written size.
+  auto ValidateMeasure = [&]() {
+    auto ActualBytes = std::filesystem::file_size(SnapshotFN);
+    if (MeasuredBytes != ActualBytes) {
+      std::cerr << "Bytes snapshot measured " << MeasuredBytes << " but wrote "
+                << ActualBytes << "\n";
+      return 512;
+    }
+
+    auto ActualDiff = std::filesystem::file_size(DiffSnapshotFN);
+    if (MeasuredDiff != ActualDiff) {
+      std::cerr << "Diff snapshot measured " << MeasuredDiff << " but wrote "
+                << ActualDiff << "\n";
+      return 512;
     }
     return 0;
   }();
@@ -447,7 +466,7 @@ int main(int argc, char **argv) {
   auto Ret = ValidateGlobalMem | ValidateDeviceMem | ValidateKernelArgs |
              ValidateDiffGlobalMem | ValidateDiffDeviceMem |
              ValidateDiffKernelArgs | ValidateBestSparse |
-             ValidateBestFragmented | ValidateHeaderParse;
+             ValidateBestFragmented | ValidateMeasure | ValidateHeaderParse;
 
   delete[] GlobalData.second;
   delete[] BlobData.second;

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -426,8 +426,7 @@ int main(int argc, char **argv) {
     return 0;
   }();
 
-  // SnapshotHeader::parse is the only code that identifies a file, so pin all
-  // three prefixes it recognises.
+  // Pin all three prefixes SnapshotHeader::parse recognises.
   auto ValidateHeaderParse = [&]() {
     char Container[SnapshotHeader::Size];
     std::memcpy(Container, SnapshotHeader::Magic,
@@ -458,6 +457,27 @@ int main(int argc, char **argv) {
     if (BytesHeader.Kind != SnapshotKind::Bytes || BytesHeader.Version != 0 ||
         BytesOffset != 0) {
       std::cerr << "Unprefixed buffer did not parse as {Bytes, 0, 0}\n";
+      return 256;
+    }
+
+    auto parseFilePrefix = [](const std::filesystem::path &Path) {
+      std::ifstream FileIn(Path, std::ios::binary);
+      std::string Prefix(SnapshotHeader::Size, '\0');
+      FileIn.read(Prefix.data(), Prefix.size());
+      return SnapshotHeader::parse(Prefix);
+    };
+
+    auto [PrologueHeader, PrologueOffset] = parseFilePrefix(SnapshotFN);
+    if (PrologueHeader.Kind != SnapshotKind::Bytes ||
+        PrologueHeader.Version != 0 || PrologueOffset != 16) {
+      std::cerr << "Prologue file did not parse as {Bytes, 0, 16}\n";
+      return 256;
+    }
+
+    auto [DiffFileHeader, DiffFileOffset] = parseFilePrefix(DiffSnapshotFN);
+    if (DiffFileHeader.Kind != SnapshotKind::Diff ||
+        DiffFileHeader.Version != 1 || DiffFileOffset != 16) {
+      std::cerr << "Diff file did not parse as {Diff, 1, 16}\n";
       return 256;
     }
     return 0;

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -25,13 +25,6 @@ using MnemeDeviceRT = DeviceTraits<DeviceVendors::CUDA>;
 using MnemeMemoryBlobDevice = MnemeMemoryBlob<DeviceVendors::CUDA>;
 #endif
 
-bool isDiffSnapshotFile(const std::filesystem::path &Path) {
-  std::ifstream In(Path, std::ios::binary);
-  std::string Magic(13, '\0');
-  In.read(Magic.data(), Magic.size());
-  return Magic == "MNEME_DIFF_V1";
-}
-
 template <typename T> void initializeRandomBuffer(T *Buffer, size_t Size) {
   // Random number generation setup
   std::mt19937 gen(4); // Mersenne Twister random number generator
@@ -109,8 +102,8 @@ int main(int argc, char **argv) {
       GVars, DeviceMemMap, SnapshotFN, TestKernel->KernelArgSizes, Args, 0,
       &PrologueGlobals);
 
-  auto ReadSnap =
-      MnemeSnapshot<Vendor>::readBytesSnapshot(KernelName, SnapshotFN.string());
+  auto ReadSnap = SnapshotFormatRegistry<Vendor>::open(SnapshotFN.string())
+                      ->read(KernelName, BaseSnapshotSource<Vendor>());
   auto &ReadGVars = ReadSnap.GlobalVars;
   auto &ReadDeviceMemMap = ReadSnap.DeviceMemory;
   auto &RTestKernel = ReadSnap.KInfo;
@@ -253,8 +246,9 @@ int main(int argc, char **argv) {
   MnemeSnapshot<Vendor>::takeMnemeDiffSnapshot(
       GVars, DeviceMemMap, DiffSnapshotFN, PrologueGlobals, 0);
 
-  auto DiffSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
-      KernelName, DiffSnapshotFN.string(), SnapshotFN.string());
+  auto DiffSnap =
+      SnapshotFormatRegistry<Vendor>::open(DiffSnapshotFN.string())
+          ->read(KernelName, BaseSnapshotSource<Vendor>(SnapshotFN.string()));
   auto &DiffGVars = DiffSnap.GlobalVars;
   auto &DiffDeviceMemMap = DiffSnap.DeviceMemory;
   auto &DiffKernel = DiffSnap.KInfo;
@@ -343,12 +337,14 @@ int main(int argc, char **argv) {
       GVars, DeviceMemMap, SparseBestSnapshotFN, EmptyArgSizes, nullptr,
       PrologueGlobals, 0);
   auto ValidateBestSparse = [&]() {
-    if (!isDiffSnapshotFile(SparseBestSnapshotFN)) {
+    if (SnapshotFormatRegistry<Vendor>::open(SparseBestSnapshotFN.string())
+            ->isSelfContained()) {
       std::cerr << "Best sparse snapshot should choose diff\n";
       return 64;
     }
-    auto BestSparseSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
-        KernelName, SparseBestSnapshotFN.string(), SnapshotFN.string());
+    auto BestSparseSnap =
+        SnapshotFormatRegistry<Vendor>::open(SparseBestSnapshotFN.string())
+            ->read(KernelName, BaseSnapshotSource<Vendor>(SnapshotFN.string()));
     auto It = BestSparseSnap.DeviceMemory.find((void *)BlobData.first);
     if (It == BestSparseSnap.DeviceMemory.end() ||
         std::memcmp(BlobData.second, It->second.getHostData().get(), 128) !=
@@ -392,12 +388,14 @@ int main(int argc, char **argv) {
       GVars, DeviceMemMap, FragmentedBestSnapshotFN, EmptyArgSizes, nullptr,
       PrologueGlobals, 0);
   auto ValidateBestFragmented = [&]() {
-    if (isDiffSnapshotFile(FragmentedBestSnapshotFN)) {
+    if (!SnapshotFormatRegistry<Vendor>::open(FragmentedBestSnapshotFN.string())
+             ->isSelfContained()) {
       std::cerr << "Best fragmented snapshot should choose bytes\n";
       return 128;
     }
-    auto BestFragmentedSnap = MnemeSnapshot<Vendor>::readDiffSnapshot(
-        KernelName, FragmentedBestSnapshotFN.string(), SnapshotFN.string());
+    auto BestFragmentedSnap =
+        SnapshotFormatRegistry<Vendor>::open(FragmentedBestSnapshotFN.string())
+            ->read(KernelName, BaseSnapshotSource<Vendor>(SnapshotFN.string()));
     auto It = BestFragmentedSnap.DeviceMemory.find((void *)BlobData.first);
     if (It == BestFragmentedSnap.DeviceMemory.end() ||
         std::memcmp(BlobData.second, It->second.getHostData().get(), 128) !=
@@ -409,10 +407,47 @@ int main(int argc, char **argv) {
     return 0;
   }();
 
+  // SnapshotHeader::parse is the only code that identifies a file, so pin all
+  // three prefixes it recognises.
+  auto ValidateHeaderParse = [&]() {
+    char Container[SnapshotHeader::Size];
+    std::memcpy(Container, SnapshotHeader::Magic,
+                sizeof(SnapshotHeader::Magic));
+    uint32_t Kind = 2;
+    uint32_t Version = 7;
+    std::memcpy(Container + 8, &Kind, sizeof(Kind));
+    std::memcpy(Container + 12, &Version, sizeof(Version));
+    auto [ContainerHeader, ContainerOffset] =
+        SnapshotHeader::parse(llvm::StringRef(Container, sizeof(Container)));
+    if (ContainerHeader.Kind != SnapshotKind::Diff ||
+        ContainerHeader.Version != 7 || ContainerOffset != 16) {
+      std::cerr << "Container prefix did not parse as {Diff, 7, 16}\n";
+      return 256;
+    }
+
+    std::string Legacy("MNEME_DIFF_V1");
+    Legacy += "arbitrary diff payload";
+    auto [LegacyHeader, LegacyOffset] = SnapshotHeader::parse(Legacy);
+    if (LegacyHeader.Kind != SnapshotKind::Diff || LegacyHeader.Version != 1 ||
+        LegacyOffset != 13) {
+      std::cerr << "Legacy diff magic did not parse as {Diff, 1, 13}\n";
+      return 256;
+    }
+
+    std::string Headerless("arbitrary bytes snapshot payload");
+    auto [BytesHeader, BytesOffset] = SnapshotHeader::parse(Headerless);
+    if (BytesHeader.Kind != SnapshotKind::Bytes || BytesHeader.Version != 0 ||
+        BytesOffset != 0) {
+      std::cerr << "Unprefixed buffer did not parse as {Bytes, 0, 0}\n";
+      return 256;
+    }
+    return 0;
+  }();
+
   auto Ret = ValidateGlobalMem | ValidateDeviceMem | ValidateKernelArgs |
              ValidateDiffGlobalMem | ValidateDiffDeviceMem |
              ValidateDiffKernelArgs | ValidateBestSparse |
-             ValidateBestFragmented;
+             ValidateBestFragmented | ValidateHeaderParse;
 
   delete[] GlobalData.second;
   delete[] BlobData.second;

--- a/tests/unit_tests/ReadWriteSnapshot.cpp
+++ b/tests/unit_tests/ReadWriteSnapshot.cpp
@@ -340,8 +340,8 @@ int main(int argc, char **argv) {
   std::filesystem::path SparseBestSnapshotFN("./test.best.sparse.mneme");
   BestWriter<Vendor>(PrologueGlobals).write(SparseBestSnapshotFN, InNoArgs);
   auto ValidateBestSparse = [&]() {
-    if (SnapshotFormatRegistry<Vendor>::open(SparseBestSnapshotFN.string())
-            ->isSelfContained()) {
+    if (!SnapshotFormatRegistry<Vendor>::open(SparseBestSnapshotFN.string())
+             ->requiresBaseSnapshot()) {
       std::cerr << "Best sparse snapshot should choose diff\n";
       return 64;
     }
@@ -389,8 +389,8 @@ int main(int argc, char **argv) {
       "./test.best.fragmented.mneme");
   BestWriter<Vendor>(PrologueGlobals).write(FragmentedBestSnapshotFN, InNoArgs);
   auto ValidateBestFragmented = [&]() {
-    if (!SnapshotFormatRegistry<Vendor>::open(FragmentedBestSnapshotFN.string())
-             ->isSelfContained()) {
+    if (SnapshotFormatRegistry<Vendor>::open(FragmentedBestSnapshotFN.string())
+            ->requiresBaseSnapshot()) {
       std::cerr << "Best fragmented snapshot should choose bytes\n";
       return 128;
     }

--- a/tests/unit_tests/SerializeGlobals.cpp
+++ b/tests/unit_tests/SerializeGlobals.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
                             GV.VarSize);
 
   auto Buff = const_cast<const char *>(Buffer.data());
-  auto tmp = mneme::MnemeSnapshot<Vendor>::fromBuffer(Buff);
+  auto tmp = mneme::readGlobalVarRecord(Buff);
   auto &GName = tmp.first;
   auto &GVR   = tmp.second;
 


### PR DESCRIPTION
We are evolving Mneme's binary format in different ways (#188) is one example. At the same time, we are building persistent recording databases and adding new features to Mneme. This portends binary compatibility hell, which this branch diverts us from.

We create an interface for reading/writing Mneme's binary formats, with versioned readers.