### PR TITLE
ci: charge Matrix allocations to the asccasc bank

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -55,9 +55,9 @@ variables:
 # Time in minutes.
 # Arguments for top level allocation
 # Note: can be set to "OFF" to prevent allocation sharing.
-  MATRIX_SHARED_ALLOC: "--gpus=1 --nodes=1 --time=60 --partition=pdebug"
+  MATRIX_SHARED_ALLOC: "--account=${FLUX_BANK} --gpus=1 --nodes=1 --time=60 --partition=pdebug"
 # Arguments for job level allocation
-  MATRIX_JOB_ALLOC: "--gpus=1 --nodes=1"
+  MATRIX_JOB_ALLOC: "--account=${FLUX_BANK} --gpus=1 --nodes=1"
 
 # Tuo
 # Arguments for top level allocation


### PR DESCRIPTION
Matrix CI jobs did not pass a Slurm account, so they were charged to the default `guests` account. That account has a very small share and a fairshare score near zero, so jobs sat in the queue long enough to hit the pipeline timeout. Tioga and Tuolumne jobs already charge `asccasc` through `FLUX_BANK`.

- Add `--account=${FLUX_BANK}` to `MATRIX_SHARED_ALLOC`
- Add `--account=${FLUX_BANK}` to `MATRIX_JOB_ALLOC`